### PR TITLE
refactor: 커뮤니티 글 이미지 엔티티에 createdAt 컬럼 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/entity/CommunityPostImage.java
+++ b/src/main/java/kr/bi/greenmate/entity/CommunityPostImage.java
@@ -13,6 +13,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -30,4 +33,8 @@ public class CommunityPostImage {
 
     @Column(length = 50, nullable = false, updatable = false)
     private String imageUrl;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 }


### PR DESCRIPTION
### 개요
커뮤니티 글 이미지 테이블에 created_at 컬럼을 추가했습니다.

### 변경사항
- community_post_image 테이블 DDL에 created_at 컬럼 추가
- 이에 맞춰 CommunityPostImage 엔티티 코드 수정

### 리뷰어에게 하고 싶은 말
더 보완할 부분 있으면 알려주세요!

에어컨을 많이 틀어서 그런지 목이 아프네요
다들 냉방병 조심하세요!!!