### PR TITLE
TEAM1-80 배포 실패 오류 해결

### DIFF
--- a/src/main/java/kr/bi/greenmate/config/SecurityConfig.java
+++ b/src/main/java/kr/bi/greenmate/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/api-docs/**",
                 "/swagger-resources/**",
-                "/actuator/**"
+                "/actuator/health/**"
         );
     }
 

--- a/src/main/java/kr/bi/greenmate/config/SecurityConfig.java
+++ b/src/main/java/kr/bi/greenmate/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
                 "/api-docs/**",
-                "/swagger-resources/**"
+                "/swagger-resources/**",
+                "/actuator/**"
         );
     }
 


### PR DESCRIPTION
### 개요
- spring 액츄에이터가 로그인 필터에 막혀서 403이 발생하고 있었다
- 그러나 액츄에이터는 서버가 살아있는지 판단하는 조건으로 사용됨
- 따라서 에러가 발생하니 서버가 죽었다고 판단되서 배포가 성공하지 못함

### 변경사항
- 액츄에이터 Path 하위 모두 로그인 없이 접근 허용


### 리뷰어에게 하고 싶은 말
- 리뷰할때 이걸 제가 챙겼어야 하는데 잊고있었네요 ㅋㅋ큐ㅠㅠ
