### PR TITLE
TEAM1-88 feat: 회원가입 요청에서 자기소개 필드 삭제

### DIFF
--- a/src/main/java/kr/bi/greenmate/dto/SignUpRequest.java
+++ b/src/main/java/kr/bi/greenmate/dto/SignUpRequest.java
@@ -32,11 +32,6 @@ public class SignUpRequest {
     @Schema(description = "사용자 비밀번호", example = "password123", minLength = 8, maxLength = 60)
     private String password;
 
-    @NotBlank(message = "자기소개는 필수입니다.")
-    @Size(max = 300, message = "자기소개는 300자 이하여야 합니다.")
-    @Schema(description = "사용자 자기소개", example = "환경 보호에 관심이 많은 사용자입니다.", maxLength = 300)
-    private String selfIntroduction;
-
     @Setter
     @Schema(description = "프로필 이미지 파일")
     private MultipartFile profileImage;

--- a/src/main/java/kr/bi/greenmate/entity/User.java
+++ b/src/main/java/kr/bi/greenmate/entity/User.java
@@ -41,7 +41,7 @@ public class User extends BaseTimeEntity {
     @Column(length = 50) 
     private String profileImageUrl; 
 
-    @Column(nullable = false, length = 300) 
+    @Column(length = 300)
     private String selfIntroduction; 
 
     // oneToMany 관계 추가 예정

--- a/src/main/java/kr/bi/greenmate/service/AuthService.java
+++ b/src/main/java/kr/bi/greenmate/service/AuthService.java
@@ -81,7 +81,6 @@ public class AuthService {
             .nickname(request.getNickname())
             .password(passwordEncoder.encode(request.getPassword()))
             .profileImageUrl(profileImageUrl)
-            .selfIntroduction(request.getSelfIntroduction())
             .build();
     }
 


### PR DESCRIPTION
### 개요
회원가입 요청에서 자기소개 필드를 제거합니다. 
사용자 기본 자기소개를 Null로 할당하고 추후에 사용자가 설정할 수 있도록 변경합니다.

### 변경사항
- 회원가입 request의 자기소개 필드 제거
- User 엔티티의 자기소개 필드 `nullable = false` 제거
- createUser 빌더의 자기소개 필드 제거

### 리뷰어에게 하고 싶은 말
현재 main문에서 발생하는 에러를 해결하는 커밋을 추가하겠습니다. (conflict 방지) 