### PR TITLE
TEAM1-44 feat: 커뮤니티 글 댓글 작성 API 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -91,7 +91,6 @@ public class CommunityPostController {
 	public ResponseEntity<CommunityPostCommentResponse> createComment(
 		@Parameter(description = "댓글을 작성할 커뮤니티 글 ID", example = "123")
 		@PathVariable long postId,
-		@Parameter(description = "인증된 사용자", hidden = true)
 		@AuthenticationPrincipal User user,
 		@Parameter(description = "댓글 작성 요청 본문", required = true)
 		@RequestPart("request") @Valid CommunityPostCommentRequest request,

--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -20,6 +20,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
+import kr.bi.greenmate.dto.CommunityPostCommentRequest;
+import kr.bi.greenmate.dto.CommunityPostCommentResponse;
 import kr.bi.greenmate.dto.CommunityPostCreateRequest;
 import kr.bi.greenmate.dto.CommunityPostCreateResponse;
 import kr.bi.greenmate.dto.CommunityPostDetailResponse;
@@ -82,5 +84,23 @@ public class CommunityPostController {
 		CommunityPostDetailResponse response = communityPostService.getPost(postId, user);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping(value = "/{postId}/comments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "커뮤니티 댓글 작성", description = "특정 커뮤니티 글에 댓글을 작성합니다.")
+	public ResponseEntity<CommunityPostCommentResponse> createComment(
+		@Parameter(description = "댓글을 작성할 커뮤니티 글 ID", example = "123")
+		@PathVariable long postId,
+		@Parameter(description = "인증된 사용자", hidden = true)
+		@AuthenticationPrincipal User user,
+		@Parameter(description = "댓글 작성 요청 본문", required = true)
+		@RequestPart("request") @Valid CommunityPostCommentRequest request,
+		@Parameter(description = "첨부 이미지 (최대 1개)", example = "comment.jpg")
+		@RequestPart(value = "image", required = false) MultipartFile image) {
+
+		CommunityPostCommentResponse response =
+			communityPostService.createComment(postId, user, request, image);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentRequest.java
+++ b/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentRequest.java
@@ -1,0 +1,20 @@
+package kr.bi.greenmate.dto;
+
+import org.springframework.lang.Nullable;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CommunityPostCommentRequest {
+	@NotBlank(message = "댓글 내용은 필수입니다.")
+	@Schema(description = "댓글 내용", example = "정말 좋은 글이네요!")
+	@Size(max = 100, message = "댓글 내용은 100자 이하여야 합니다.")
+	private String content;
+
+	@Nullable
+	@Schema(description = "부모 댓글 ID (대댓글인 경우에만 사용)", example = "10")
+	private Long parentCommentId;
+}

--- a/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentResponse.java
+++ b/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentResponse.java
@@ -1,0 +1,28 @@
+package kr.bi.greenmate.dto;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "커뮤니티 댓글 응답 DTO")
+public class CommunityPostCommentResponse {
+
+	@Schema(description = "댓글 ID")
+	private Long id;
+
+	@Schema(description = "댓글 작성자 ID")
+	private Long userId;
+
+	@Schema(description = "댓글 작성자 닉네임")
+	private String nickname;
+
+	@Schema(description = "댓글 내용")
+	private String content;
+
+	@Schema(description = "작성 시간")
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/bi/greenmate/entity/CommunityPost.java
+++ b/src/main/java/kr/bi/greenmate/entity/CommunityPost.java
@@ -75,4 +75,8 @@ public class CommunityPost extends BaseTimeEntity {
 			this.likeCount--;
 		}
 	}
+
+	public void incrementCommentCount() {
+		this.commentCount++;
+	}
 }

--- a/src/main/java/kr/bi/greenmate/entity/CommunityPostComment.java
+++ b/src/main/java/kr/bi/greenmate/entity/CommunityPostComment.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,4 +42,7 @@ public class CommunityPostComment extends BaseTimeEntity {
 
 	@Column(length = 50)
 	private String imageUrl;
+
+	@Version
+	private Long version;
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -1,5 +1,7 @@
 package kr.bi.greenmate.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,9 +9,12 @@ import org.springframework.data.repository.query.Param;
 import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
-	
+
 	@Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END " +
 		"FROM CommunityPostComment c " +
 		"WHERE c.id = :commentId AND c.parent.id = :postId")
 	boolean existsByCommentIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
+
+	@Query("SELECT c FROM CommunityPostComment c WHERE c.id = :commentId AND c.parent.id = :postId")
+	Optional<CommunityPostComment> findByIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -1,0 +1,15 @@
+package kr.bi.greenmate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import kr.bi.greenmate.entity.CommunityPostComment;
+
+public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
+	
+	@Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END " +
+		"FROM CommunityPostComment c " +
+		"WHERE c.id = :commentId AND c.parent.id = :postId")
+	boolean existsByCommentIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
+}

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -3,13 +3,10 @@ package kr.bi.greenmate.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
 import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
-	
-	boolean existsByCommentIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
 
-	Optional<CommunityPostComment> findByIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
+	Optional<CommunityPostComment> findByIdAndParentId(Long commentId, Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -3,18 +3,13 @@ package kr.bi.greenmate.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
-
-	@Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END " +
-		"FROM CommunityPostComment c " +
-		"WHERE c.id = :commentId AND c.parent.id = :postId")
+	
 	boolean existsByCommentIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
 
-	@Query("SELECT c FROM CommunityPostComment c WHERE c.id = :commentId AND c.parent.id = :postId")
 	Optional<CommunityPostComment> findByIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
@@ -1,0 +1,71 @@
+package kr.bi.greenmate.service;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.OptimisticLockException;
+import kr.bi.greenmate.dto.CommunityPostCommentRequest;
+import kr.bi.greenmate.dto.CommunityPostCommentResponse;
+import kr.bi.greenmate.entity.CommunityPost;
+import kr.bi.greenmate.entity.CommunityPostComment;
+import kr.bi.greenmate.entity.User;
+import kr.bi.greenmate.exception.error.ParentCommentMismatchException;
+import kr.bi.greenmate.exception.error.PostNotFoundException;
+import kr.bi.greenmate.repository.CommunityPostCommentRepository;
+import kr.bi.greenmate.repository.CommunityPostRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCreationService {
+
+	private final CommunityPostRepository communityPostRepository;
+	private final CommunityPostCommentRepository communityPostCommentRepository;
+
+	@Transactional
+	@Retryable(
+		retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 50)
+	)
+	public CommunityPostCommentResponse createCommentInTransaction(Long postId, User user,
+		CommunityPostCommentRequest request, String imageUrl) {
+
+		CommunityPost post = communityPostRepository.findById(postId)
+			.orElseThrow(PostNotFoundException::new);
+
+		CommunityPostComment parent = communityPostCommentRepository
+			.findByIdAndParentId(request.getParentCommentId(), postId)
+			.orElseThrow(ParentCommentMismatchException::new);
+
+		CommunityPostComment comment = CommunityPostComment.builder()
+			.parent(post).user(user).content(request.getContent())
+			.imageUrl(imageUrl).communityPostComment(parent).build();
+
+		communityPostCommentRepository.save(comment);
+		post.incrementCommentCount();
+		return buildCommentResponse(comment);
+	}
+
+	private CommunityPostComment validateParentComment(Long parentCommentId, Long postId) {
+		if (parentCommentId == null)
+			return null;
+
+		return communityPostCommentRepository
+			.findByIdAndParentId(parentCommentId, postId)
+			.orElseThrow(ParentCommentMismatchException::new);
+	}
+
+	private CommunityPostCommentResponse buildCommentResponse(CommunityPostComment comment) {
+		return CommunityPostCommentResponse.builder()
+			.id(comment.getId())
+			.userId(comment.getUser().getId())
+			.nickname(comment.getUser().getNickname())
+			.content(comment.getContent())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -281,7 +281,7 @@ public class CommunityPostService {
 			return null;
 
 		return communityPostCommentRepository
-			.findByIdAndPostId(parentCommentId, postId)
+			.findByIdAndParentId(parentCommentId, postId)
 			.orElseThrow(ParentCommentMismatchException::new);
 	}
 

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -277,18 +277,12 @@ public class CommunityPostService {
 	}
 
 	private CommunityPostComment validateParentComment(Long parentCommentId, Long postId) {
-		if (parentCommentId == null) {
+		if (parentCommentId == null)
 			return null;
-		}
 
-		CommunityPostComment parentComment = communityPostCommentRepository.findById(parentCommentId)
-			.orElseThrow(CommentNotFoundException::new);
-
-		if (!communityPostCommentRepository.existsByCommentIdAndPostId(parentCommentId, postId)) {
-			throw new ParentCommentMismatchException();
-		}
-
-		return parentComment;
+		return communityPostCommentRepository
+			.findByIdAndPostId(parentCommentId, postId)
+			.orElseThrow(ParentCommentMismatchException::new);
 	}
 
 	private CommunityPostCommentResponse buildCommentResponse(CommunityPostComment comment) {

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -249,7 +249,7 @@ public class CommunityPostService {
 
 		try {
 			return imageUploadService.upload(image, "community-comment");
-		} catch (Exception e) {
+		} catch (RuntimeException e) {
 			throw new FileUploadFailException();
 		}
 	}

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -55,6 +55,7 @@ public class CommunityPostService {
 	private final ObjectStorageRepository objectStorageRepository;
 	private final ImageUploadService imageUploadService;
 	private final ViewCountService viewCountService;
+	private final CommentCreationService commentCreationService;
 	private final CommunityPostCommentRepository communityPostCommentRepository;
 
 	@Transactional
@@ -223,18 +224,12 @@ public class CommunityPostService {
 		return new KeysetSliceResponse<>(content, slice.hasNext());
 	}
 
-	@Transactional
-	@Retryable(
-		retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
-		maxAttempts = 3,
-		backoff = @Backoff(delay = 50)
-	)
 	public CommunityPostCommentResponse createComment(Long postId, User user,
 		CommunityPostCommentRequest request, MultipartFile image) {
 
 		String imageUrl = processCommentImage(image);
 
-		return doCreateComment(postId, user, request, imageUrl);
+		return commentCreationService.createCommentInTransaction(postId, user, request, imageUrl);
 	}
 
 	private String processCommentImage(MultipartFile image) {


### PR DESCRIPTION
### 개요
커뮤니티 글 댓글 작성 API 추가했습니다.

### 변경사항
- 댓글 작성 메서드 추가
- `CommunityPostCommentRequest` / `Response` DTO 추가
- `CommunityPostCommentRepository` 추가

### 리뷰어에게 하고 싶은 말
```
@Transactional
	@Retryable(
		retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
		maxAttempts = 3,
		backoff = @Backoff(delay = 50)
	)
	public CommunityPostCommentResponse createComment(Long postId, User user,
		CommunityPostCommentRequest request, MultipartFile image)
```
위와 같이 `@Retryable`애노테이션을 이용하여 동시성 이슈를 해결하려 했으나

동시 접근 시에 이미 업로드한 파일을 다시 업로드하게 되는 문제가 생긴다는 것을 알았습니다.

그래서 이미지를 업로드한 뒤에 Trasactional, Retryable를 적용할 수 있도록 메서드를 분리하려 했는데, 같은 클래스 안에서 메서드를 호출하면 애노테이션이 작동하지 않는다는 메시지가 발생했습니다. 

_(@Transactional self-invocation (in effect, a method within the target object calling another method of the target object) does not lead to an actual transaction at runtime )_

이와 같은 경우에는 클래스 자체를 분리하여 전달하는게 좋은지 궁금합니다!