### PR TITLE
TEAM1-42 feat: 커뮤니티 글 댓글 조회 API 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -102,4 +102,20 @@ public class CommunityPostController {
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
+
+	@GetMapping("/{postId}/comments")
+	@Operation(summary = "커뮤니티 글 댓글 목록 조회", description = "특정 커뮤니티 글의 댓글 목록을 무한 스크롤로 조회합니다.")
+	public ResponseEntity<KeysetSliceResponse<CommunityPostCommentResponse>> getComments(
+		@Parameter(description = "댓글을 조회할 커뮤니티 글 ID", example = "123")
+		@PathVariable long postId,
+		@Parameter(description = "마지막으로 조회한 댓글 ID (첫 페이지면 생략)", example = "100")
+		@RequestParam(required = false) Long lastCommentId,
+		@Parameter(description = "한 번에 조회할 댓글 수", example = "10")
+		@RequestParam(defaultValue = "10") int size) {
+
+		KeysetSliceResponse<CommunityPostCommentResponse> response =
+			communityPostService.getComments(postId, lastCommentId, size);
+
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentResponse.java
+++ b/src/main/java/kr/bi/greenmate/dto/CommunityPostCommentResponse.java
@@ -23,6 +23,9 @@ public class CommunityPostCommentResponse {
 	@Schema(description = "댓글 내용")
 	private String content;
 
+	@Schema(description = "댓글 이미지 URL / nullable")
+	private String imageUrl;
+
 	@Schema(description = "작성 시간")
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/bi/greenmate/dto/KeysetSliceResponse.java
+++ b/src/main/java/kr/bi/greenmate/dto/KeysetSliceResponse.java
@@ -12,9 +12,13 @@ import lombok.Getter;
 @Builder
 @Schema(description = "Keyset 기반 페이징 응답")
 public class KeysetSliceResponse<T> {
+
 	@Schema(description = "데이터 목록")
-	private List<T> content;
+	private final List<T> content;
 
 	@Schema(description = "다음 페이지 존재 여부")
-	private Boolean hasNext;
+	private final Boolean hasNext;
+
+	@Schema(description = "다음 페이지 커서 (마지막 아이템 id)")
+	private final Long lastId;
 }

--- a/src/main/java/kr/bi/greenmate/dto/KeysetSliceResponse.java
+++ b/src/main/java/kr/bi/greenmate/dto/KeysetSliceResponse.java
@@ -3,22 +3,13 @@ package kr.bi.greenmate.dto;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-@Builder
 @Schema(description = "Keyset 기반 페이징 응답")
-public class KeysetSliceResponse<T> {
+public record KeysetSliceResponse<T>(
 
-	@Schema(description = "데이터 목록")
-	private final List<T> content;
+	@Schema(description = "데이터 목록") List<T> content,
 
-	@Schema(description = "다음 페이지 존재 여부")
-	private final Boolean hasNext;
+	@Schema(description = "다음 페이지 존재 여부") Boolean hasNext,
 
-	@Schema(description = "다음 페이지 커서 (마지막 아이템 id)")
-	private final Long lastId;
+	@Schema(description = "다음 페이지 커서 (마지막 아이템 id)") Long lastId) {
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -1,12 +1,23 @@
 package kr.bi.greenmate.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
 
+	boolean existsByIdAndParentId(Long commentId, Long postId);
+
 	Optional<CommunityPostComment> findByIdAndParentId(Long commentId, Long postId);
+
+	@EntityGraph(attributePaths = "user")
+	List<CommunityPostComment> findByParent_IdOrderByIdDesc(Long postId, Pageable pageable);
+
+	@EntityGraph(attributePaths = "user")
+	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -11,8 +11,6 @@ import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
 
-	boolean existsByIdAndParentId(Long commentId, Long postId);
-
 	Optional<CommunityPostComment> findByIdAndParentId(Long commentId, Long postId);
 
 	@EntityGraph(attributePaths = "user")

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -11,8 +11,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,11 +32,9 @@ import kr.bi.greenmate.entity.User;
 import kr.bi.greenmate.exception.error.FileUploadFailException;
 import kr.bi.greenmate.exception.error.ImageCountExceedException;
 import kr.bi.greenmate.exception.error.ImageSizeExceedException;
-import kr.bi.greenmate.exception.error.InvalidImageTypeException;
 import kr.bi.greenmate.exception.error.OptimisticLockCustomException;
 import kr.bi.greenmate.exception.error.ParentCommentMismatchException;
 import kr.bi.greenmate.exception.error.PostNotFoundException;
-import kr.bi.greenmate.exception.error.CommentNotFoundException;
 import kr.bi.greenmate.repository.CommunityPostCommentRepository;
 import kr.bi.greenmate.repository.CommunityPostImageRepository;
 import kr.bi.greenmate.repository.CommunityPostLikeRepository;
@@ -221,7 +217,9 @@ public class CommunityPostService {
 				.build())
 			.toList();
 
-		return new KeysetSliceResponse<>(content, slice.hasNext());
+		Long newLastId = content.isEmpty() ? null : content.get(content.size() - 1).getPostId();
+
+		return new KeysetSliceResponse<>(content, slice.hasNext(), newLastId);
 	}
 
 	public CommunityPostCommentResponse createComment(Long postId, User user,
@@ -288,5 +286,31 @@ public class CommunityPostService {
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())
 			.build();
+	}
+
+	@Transactional(readOnly = true)
+	public KeysetSliceResponse<CommunityPostCommentResponse> getComments(Long postId, Long lastCommentId, int size) {
+
+		communityPostRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+
+		Pageable pageable = PageRequest.of(0, size + 1);
+		List<CommunityPostComment> results;
+
+		if (lastCommentId == null) {
+			results = communityPostCommentRepository.findByParent_IdOrderByIdDesc(postId, pageable);
+		} else {
+			results = communityPostCommentRepository.findByParent_IdAndIdLessThanOrderByIdDesc(postId, lastCommentId,
+				pageable);
+		}
+
+		boolean hasNext = results.size() > size;
+		List<CommunityPostCommentResponse> content = results.stream()
+			.limit(size)
+			.map(this::buildCommentResponse)
+			.toList();
+
+		Long newLastId = content.isEmpty() ? null : content.get(content.size() - 1).getId();
+
+		return new KeysetSliceResponse<>(content, hasNext, newLastId);
 	}
 }

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -291,7 +291,9 @@ public class CommunityPostService {
 	@Transactional(readOnly = true)
 	public KeysetSliceResponse<CommunityPostCommentResponse> getComments(Long postId, Long lastCommentId, int size) {
 
-		communityPostRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+		if (!communityPostRepository.existsById(postId)) {
+			throw new PostNotFoundException();
+		}
 
 		Pageable pageable = PageRequest.of(0, size + 1);
 		List<CommunityPostComment> results;

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -284,6 +284,8 @@ public class CommunityPostService {
 			.userId(comment.getUser().getId())
 			.nickname(comment.getUser().getNickname())
 			.content(comment.getContent())
+			.imageUrl(comment.getImageUrl() == null ? null
+				: objectStorageRepository.getDownloadUrl(comment.getImageUrl()))
 			.createdAt(comment.getCreatedAt())
 			.build();
 	}


### PR DESCRIPTION
### 개요
커뮤니티 글 댓글을 Keyset 기반 무한스크롤로 조회할 수 있는 API 추가했습니다

### 변경사항
- getComments 메서드 추가했습니다.
- KeysetSliceResopnse에 newLastId 필드를 추가했습니다.

### 리뷰어에게 하고 싶은 말
여정님의 모집 댓글 조회와 기능은 같은데 코드가 많이 달라지는 것을 보니 페이징에 대한 공부도 많이 해봐야할 것 같네요,,,