### PR TITLE
TEAM1-59 feat: 회원 탈퇴 API 작업

### DIFF
--- a/src/main/java/kr/bi/greenmate/GreenMateApplication.java
+++ b/src/main/java/kr/bi/greenmate/GreenMateApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @ConfigurationPropertiesScan
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @EnableRetry
+@EnableAsync
 public class GreenMateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/bi/greenmate/config/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/bi/greenmate/config/JwtAuthenticationFilter.java
@@ -35,9 +35,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			if (jwtProvider.validateToken(token)) {
 				Long userId = jwtProvider.getUserId(token);
 				userRepository.findById(userId).ifPresent(user -> {
-					var auth = new UsernamePasswordAuthenticationToken(user, null, List.of());
-					auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-					SecurityContextHolder.getContext().setAuthentication(auth);
+					if (user.getDeletedAt() == null) {
+						var auth = new UsernamePasswordAuthenticationToken(user, null, List.of());
+						auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+						SecurityContextHolder.getContext().setAuthentication(auth);
+					}
 				});
 			}
 		}

--- a/src/main/java/kr/bi/greenmate/controller/UserController.java
+++ b/src/main/java/kr/bi/greenmate/controller/UserController.java
@@ -3,6 +3,8 @@ package kr.bi.greenmate.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +23,7 @@ import kr.bi.greenmate.dto.LoginResponse;
 import kr.bi.greenmate.dto.NicknameDuplicateCheckResponse;
 import kr.bi.greenmate.dto.SignUpRequest;
 import kr.bi.greenmate.dto.SignUpResponse;
+import kr.bi.greenmate.entity.User;
 import kr.bi.greenmate.service.AuthService;
 import lombok.RequiredArgsConstructor;
 
@@ -65,5 +68,13 @@ public class UserController {
 	) {
 		LoginResponse response = authService.login(request);
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/me")
+	@Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자를 소프트 삭제합니다.")
+	public ResponseEntity<Void> deleteMe(
+		@AuthenticationPrincipal User user) {
+		authService.deleteUser(user);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/kr/bi/greenmate/controller/UserController.java
+++ b/src/main/java/kr/bi/greenmate/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
 		return ResponseEntity.ok(response);
 	}
 
-	@DeleteMapping("/me")
+	@DeleteMapping
 	@Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자를 소프트 삭제합니다.")
 	public ResponseEntity<Void> deleteMe(
 		@AuthenticationPrincipal User user) {

--- a/src/main/java/kr/bi/greenmate/entity/User.java
+++ b/src/main/java/kr/bi/greenmate/entity/User.java
@@ -51,8 +51,13 @@ public class User extends BaseTimeEntity {
 
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
-		this.nickname = "d_" + this.id;
-		this.email = "d_" + this.id;
+		String encoded = Long.toString(this.id, 36);
+		String nick = "d" + encoded;
+		if (nick.length() > 10) {
+			nick = "d" + encoded.substring(encoded.length() - 9);
+		}
+		this.nickname = nick;
+		this.email = "d" + encoded + "@deleted.user";
 	}
 
 	// oneToMany 관계 추가 예정

--- a/src/main/java/kr/bi/greenmate/entity/User.java
+++ b/src/main/java/kr/bi/greenmate/entity/User.java
@@ -51,6 +51,8 @@ public class User extends BaseTimeEntity {
 
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
+		this.nickname = "d_" + this.id;
+		this.email = "d_" + this.id;
 	}
 
 	// oneToMany 관계 추가 예정

--- a/src/main/java/kr/bi/greenmate/entity/User.java
+++ b/src/main/java/kr/bi/greenmate/entity/User.java
@@ -1,5 +1,7 @@
 package kr.bi.greenmate.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +45,13 @@ public class User extends BaseTimeEntity {
 
 	@Column(length = 300)
 	private String selfIntroduction;
+
+	@Column
+	private LocalDateTime deletedAt;
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 
 	// oneToMany 관계 추가 예정
 

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import kr.bi.greenmate.entity.CommunityPostComment;
 
@@ -19,5 +21,7 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("delete from CommunityPostComment c where c.user.id = :userId")
 	void deleteCommentsByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -18,4 +18,6 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
+
+	void deleteCommentsByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -21,7 +21,5 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("delete from CommunityPostComment c where c.user.id = :userId")
-	void deleteCommentsByUserId(Long userId);
+	void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
@@ -14,11 +14,10 @@ public interface CommunityPostImageRepository extends JpaRepository<CommunityPos
 	List<String> findImageUrlsByPostId(@Param("postId") Long postId);
 
 	@Query("""
-		    select i.imageUrl
-		    from CommunityPostImage i
-		    where i.communityPost.id in (
-		        select p.id from CommunityPost p where p.user.id = :userId
-		    )
+		  select i.imageUrl
+		  from CommunityPostImage i
+		  join i.communityPost p
+		  where p.user.id = :userId
 		""")
 	List<String> findImageKeysByOwner(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
@@ -12,4 +12,13 @@ public interface CommunityPostImageRepository extends JpaRepository<CommunityPos
 
 	@Query("SELECT cpi.imageUrl FROM CommunityPostImage cpi WHERE cpi.communityPost.id = :postId")
 	List<String> findImageUrlsByPostId(@Param("postId") Long postId);
+
+	@Query("""
+		    select i.imageUrl
+		    from CommunityPostImage i
+		    where i.communityPost.id in (
+		        select p.id from CommunityPost p where p.user.id = :userId
+		    )
+		""")
+	List<String> findImageKeysByOwner(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -39,7 +39,5 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("delete from CommunityPost p where p.user.id = :userId")
-	void deletePostsByUserId(Long userId);
+	void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -35,13 +35,11 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 		""")
 	Slice<CommunityPost> findNextPage(@Param("lastPostId") Long lastPostId, Pageable pageable);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("UPDATE CommunityPost p SET p.viewCount = p.viewCount + :delta WHERE p.id = :postId")
-	int incrementViewCountBy(@Param("postId") Long postId, @Param("delta") long delta);
-
 	@Modifying
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("delete from CommunityPost p where p.user.id = :userId")
 	void deletePostsByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -42,4 +42,6 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	@Modifying
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
+
+	void deletePostsByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
@@ -6,22 +6,26 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import kr.bi.greenmate.entity.RecruitmentPostComment;
 
 @Repository
 public interface RecruitmentPostCommentRepository extends JpaRepository<RecruitmentPostComment, Long> {
-    
-    @EntityGraph(attributePaths = "user")
-    Slice<RecruitmentPostComment> findByRecruitmentPost_IdAndParentCommentIsNullOrderByIdDesc(
-            Long recruitmentPostId, Pageable pageable);
 
-    @EntityGraph(attributePaths = "user")
-    Slice<RecruitmentPostComment> findByRecruitmentPost_IdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(
-            Long recruitmentPostId, Long lastId, Pageable pageable);
+	@EntityGraph(attributePaths = "user")
+	Slice<RecruitmentPostComment> findByRecruitmentPost_IdAndParentCommentIsNullOrderByIdDesc(
+		Long recruitmentPostId, Pageable pageable);
 
-    List<RecruitmentPostComment> findByParentCommentIdIn(List<Long> parentIds);
-  
-    void deleteByRecruitmentPostId(Long postId);
+	@EntityGraph(attributePaths = "user")
+	Slice<RecruitmentPostComment> findByRecruitmentPost_IdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(
+		Long recruitmentPostId, Long lastId, Pageable pageable);
+
+	List<RecruitmentPostComment> findByParentCommentIdIn(List<Long> parentIds);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("delete from CommunityPostComment c where c.user.id = :userId")
+	void deleteCommentsByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
@@ -25,7 +25,5 @@ public interface RecruitmentPostCommentRepository extends JpaRepository<Recruitm
 
 	List<RecruitmentPostComment> findByParentCommentIdIn(List<Long> parentIds);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("delete from CommunityPostComment c where c.user.id = :userId")
-	void deleteCommentsByUserId(Long userId);
+	void deleteByRecruitmentPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/UserRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/UserRepository.java
@@ -3,6 +3,8 @@ package kr.bi.greenmate.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import kr.bi.greenmate.entity.User;
 
@@ -12,4 +14,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByNickname(String nickname);
 
 	boolean existsByNickname(String nickname);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		  update User u
+		  set u.deletedAt = CURRENT_TIMESTAMP
+		  where u.id = :userId
+		    and u.deletedAt is null
+		""")
+	int markDeletedIfNotYet(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/service/AuthService.java
+++ b/src/main/java/kr/bi/greenmate/service/AuthService.java
@@ -48,6 +48,7 @@ public class AuthService {
 	private final ImageUploadService imageUploadService;
 	private final AgreementRepository agreementRepository;
 	private final UserAgreementRepository userAgreementRepository;
+	private final CommunityPostCleanupService communityPostCleanupService;
 
 	@Transactional
 	public SignUpResponse signUp(SignUpRequest request) {
@@ -181,6 +182,7 @@ public class AuthService {
 	@Transactional
 	public void deleteUser(User user) {
 		if (user.getDeletedAt() == null) {
+			communityPostCleanupService.deleteAllOfUser(user.getId());
 			user.softDelete();
 			userRepository.save(user);
 		}

--- a/src/main/java/kr/bi/greenmate/service/AuthService.java
+++ b/src/main/java/kr/bi/greenmate/service/AuthService.java
@@ -70,6 +70,10 @@ public class AuthService {
 	public LoginResponse login(LoginRequest request) {
 		User user = userRepository.findByEmail(request.getEmail()).orElseThrow(UserNotFoundException::new);
 
+		if (user.getDeletedAt() != null) {
+			throw new UserNotFoundException();
+		}
+
 		if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
 			throw new UserNotFoundException();
 		}
@@ -172,5 +176,13 @@ public class AuthService {
 		}
 
 		userAgreementRepository.saveAll(toSave);
+	}
+
+	@Transactional
+	public void deleteUser(User user) {
+		if (user.getDeletedAt() == null) {
+			user.softDelete();
+			userRepository.save(user);
+		}
 	}
 }

--- a/src/main/java/kr/bi/greenmate/service/AuthService.java
+++ b/src/main/java/kr/bi/greenmate/service/AuthService.java
@@ -181,10 +181,9 @@ public class AuthService {
 
 	@Transactional
 	public void deleteUser(User user) {
-		if (user.getDeletedAt() == null) {
-			communityPostCleanupService.deleteAllOfUser(user.getId());
-			user.softDelete();
-			userRepository.save(user);
-		}
+		int affected = userRepository.markDeletedIfNotYet(user.getId());
+		if (affected == 0)
+			return;
+		communityPostCleanupService.deleteAllOfUser(user.getId());
 	}
 }

--- a/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
@@ -24,6 +24,7 @@ public class CommentCreationService {
 
 	private final CommunityPostRepository communityPostRepository;
 	private final CommunityPostCommentRepository communityPostCommentRepository;
+	private final UserDisplayService userDisplayService;
 
 	@Transactional
 	@Retryable(
@@ -63,7 +64,7 @@ public class CommentCreationService {
 		return CommunityPostCommentResponse.builder()
 			.id(comment.getId())
 			.userId(comment.getUser().getId())
-			.nickname(comment.getUser().getNickname())
+			.nickname(userDisplayService.displayName(comment.getUser()))
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())
 			.build();

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
@@ -23,9 +23,9 @@ public class CommunityPostCleanupService {
 	public void deleteAllOfUser(Long userId) {
 		List<String> imageKeys = communityPostImageRepository.findImageKeysByOwner(userId);
 
-		communityPostCommentRepository.deleteCommentsByUserId(userId);
+		communityPostCommentRepository.deleteByUser_Id(userId);
 
-		communityPostRepository.deletePostsByUserId(userId);
+		communityPostRepository.deleteByUser_Id(userId);
 
 		if (!imageKeys.isEmpty()) {
 			publisher.publishEvent(new ImagesToDeleteEvent(imageKeys));

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
@@ -1,0 +1,34 @@
+package kr.bi.greenmate.service;
+
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.bi.greenmate.repository.CommunityPostCommentRepository;
+import kr.bi.greenmate.repository.CommunityPostImageRepository;
+import kr.bi.greenmate.repository.CommunityPostRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityPostCleanupService {
+	private final CommunityPostRepository communityPostRepository;
+	private final CommunityPostCommentRepository communityPostCommentRepository;
+	private final CommunityPostImageRepository communityPostImageRepository;
+	private final ApplicationEventPublisher publisher;
+
+	@Transactional
+	public void deleteAllOfUser(Long userId) {
+		List<String> imageKeys = communityPostImageRepository.findImageKeysByOwner(userId);
+
+		communityPostCommentRepository.deleteCommentsByUserId(userId);
+
+		communityPostRepository.deletePostsByUserId(userId);
+
+		if (!imageKeys.isEmpty()) {
+			publisher.publishEvent(new ImagesToDeleteEvent(imageKeys));
+		}
+	}
+}

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -53,6 +53,7 @@ public class CommunityPostService {
 	private final ViewCountService viewCountService;
 	private final CommentCreationService commentCreationService;
 	private final CommunityPostCommentRepository communityPostCommentRepository;
+	private final UserDisplayService userDisplayService;
 
 	@Transactional
 	public CommunityPostCreateResponse createPost(User user, CommunityPostCreateRequest request,
@@ -173,7 +174,7 @@ public class CommunityPostService {
 			.title(post.getTitle())
 			.content(post.getContent())
 			.imageUrls(imageUrls)
-			.authorNickname(post.getUser().getNickname())
+			.authorNickname(userDisplayService.displayName(post.getUser()))
 			.isLikedByUser(isLikedByUser)
 			.likeCount(post.getLikeCount())
 			.viewCount(displayViewCount)
@@ -208,7 +209,7 @@ public class CommunityPostService {
 			.map(post -> CommunityPostListResponse.builder()
 				.postId(post.getId())
 				.title(post.getTitle())
-				.authorNickname(post.getUser().getNickname())
+				.authorNickname(userDisplayService.displayName(post.getUser()))
 				.createdAt(post.getCreatedAt())
 				.isLikedByUser(likedPostIds.contains(post.getId()))
 				.likeCount(post.getLikeCount())
@@ -282,7 +283,7 @@ public class CommunityPostService {
 		return CommunityPostCommentResponse.builder()
 			.id(comment.getId())
 			.userId(comment.getUser().getId())
-			.nickname(comment.getUser().getNickname())
+			.nickname(userDisplayService.displayName(comment.getUser()))
 			.content(comment.getContent())
 			.imageUrl(comment.getImageUrl() == null ? null
 				: objectStorageRepository.getDownloadUrl(comment.getImageUrl()))

--- a/src/main/java/kr/bi/greenmate/service/ImagesToDeleteEvent.java
+++ b/src/main/java/kr/bi/greenmate/service/ImagesToDeleteEvent.java
@@ -1,0 +1,6 @@
+package kr.bi.greenmate.service;
+
+import java.util.List;
+
+public record ImagesToDeleteEvent(List<String> keys) {
+}

--- a/src/main/java/kr/bi/greenmate/service/RecruitmentPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/RecruitmentPostService.java
@@ -51,22 +51,23 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class RecruitmentPostService {
-    
-    private final RecruitmentPostRepository recruitmentPostRepository;
-    private final RecruitmentPostImageRepository recruitmentPostImageRepository;
-    private final ObjectStorageRepository objectStorageRepository;
-    private final UserRepository userRepository;
-    private final ImageUploadService imageUploadService;
-    private final RecruitmentPostLikeRepository recruitmentPostLikeRepository;
-    private final RecruitmentPostCommentRepository recruitmentPostCommentRepository;
 
-    public RecruitmentPostCreationResponse createRecruitmentPost(
+	private final RecruitmentPostRepository recruitmentPostRepository;
+	private final RecruitmentPostImageRepository recruitmentPostImageRepository;
+	private final ObjectStorageRepository objectStorageRepository;
+	private final UserRepository userRepository;
+	private final ImageUploadService imageUploadService;
+	private final RecruitmentPostLikeRepository recruitmentPostLikeRepository;
+	private final RecruitmentPostCommentRepository recruitmentPostCommentRepository;
+	private final UserDisplayService userDisplayService;
+
+	public RecruitmentPostCreationResponse createRecruitmentPost(
 		RecruitmentPostCreationRequest request, List<MultipartFile> images, Long userId) {
 
-        User creator = userRepository.findById(userId)
+		User creator = userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
 
-        RecruitmentPost post = RecruitmentPost.builder()
+		RecruitmentPost post = RecruitmentPost.builder()
 			.user(creator)
 			.title(request.getTitle())
 			.content(request.getContent())
@@ -74,173 +75,173 @@ public class RecruitmentPostService {
 			.recruitmentEndDate(request.getRecruitmentEndDate())
 			.build();
 
-        List<String> imageUrls = null;
-        if (images != null && !images.isEmpty()) {
-            imageUrls = images.stream()
+		List<String> imageUrls = null;
+		if (images != null && !images.isEmpty()) {
+			imageUrls = images.stream()
 				.map(file -> imageUploadService.upload(file, "recruitment-post"))
 				.collect(Collectors.toList());
 
-            List<RecruitmentPostImage> postImages = imageUrls.stream()
+			List<RecruitmentPostImage> postImages = imageUrls.stream()
 				.map(url -> RecruitmentPostImage.builder()
 					.imageUrl(url)
 					.recruitmentPost(post)
 					.build())
 				.collect(Collectors.toList());
-            post.getImages().addAll(postImages);
-        }
+			post.getImages().addAll(postImages);
+		}
 
-        RecruitmentPost savedPost = recruitmentPostRepository.save(post);
+		RecruitmentPost savedPost = recruitmentPostRepository.save(post);
 
-        return RecruitmentPostCreationResponse.builder()
+		return RecruitmentPostCreationResponse.builder()
 			.postId(savedPost.getId())
 			.title(savedPost.getTitle())
 			.createdAt(savedPost.getCreatedAt())
 			.build();
-    }
+	}
 
-    @Transactional
-    public void deleteRecruitmentPost(Long postId, Long userId) {
-        RecruitmentPost post = recruitmentPostRepository.findByIdWithUser(postId)
+	@Transactional
+	public void deleteRecruitmentPost(Long postId, Long userId) {
+		RecruitmentPost post = recruitmentPostRepository.findByIdWithUser(postId)
 			.orElseThrow(() -> new RecruitmentPostNotFoundException(postId));
 
-        if (!post.getUser().getId().equals(userId)) {
-            throw new AccessDeniedException();
-        }
+		if (!post.getUser().getId().equals(userId)) {
+			throw new AccessDeniedException();
+		}
 
-        recruitmentPostLikeRepository.deleteByRecruitmentPostId(postId);
-        recruitmentPostCommentRepository.deleteByRecruitmentPostId(postId);
-        recruitmentPostRepository.delete(post);
+		recruitmentPostLikeRepository.deleteByRecruitmentPostId(postId);
+		recruitmentPostCommentRepository.deleteByRecruitmentPostId(postId);
+		recruitmentPostRepository.delete(post);
 
-        List<RecruitmentPostImage> images = recruitmentPostImageRepository.findByRecruitmentPostId(postId);
+		List<RecruitmentPostImage> images = recruitmentPostImageRepository.findByRecruitmentPostId(postId);
 
-        deleteImagesFromObjectStorage(images);
-    }
+		deleteImagesFromObjectStorage(images);
+	}
 
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public void deleteImagesFromObjectStorage(List<RecruitmentPostImage> images) {
-        images.forEach(image -> {
-            try {
-                objectStorageRepository.delete(image.getImageUrl());
-            } catch (Exception e) {
-                log.error("Failed to delete file from object storage: {}", image.getImageUrl(), e);
-            }
-        });
-    }
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	public void deleteImagesFromObjectStorage(List<RecruitmentPostImage> images) {
+		images.forEach(image -> {
+			try {
+				objectStorageRepository.delete(image.getImageUrl());
+			} catch (Exception e) {
+				log.error("Failed to delete file from object storage: {}", image.getImageUrl(), e);
+			}
+		});
+	}
 
-    @Transactional(readOnly = true)
-    public Page<RecruitmentPostListResponse> getPostList(Pageable pageable) {
-        return recruitmentPostRepository.findAllWithUser(pageable)
-                .map(post -> RecruitmentPostListResponse.builder()
-					.postId(post.getId())
-					.title(post.getTitle())
-					.authorNickname(post.getUser().getNickname())
-					.activityDate(post.getActivityDate())
-					.createdAt(post.getCreatedAt())
-					.build());
-    }
+	@Transactional(readOnly = true)
+	public Page<RecruitmentPostListResponse> getPostList(Pageable pageable) {
+		return recruitmentPostRepository.findAllWithUser(pageable)
+			.map(post -> RecruitmentPostListResponse.builder()
+				.postId(post.getId())
+				.title(post.getTitle())
+				.authorNickname(userDisplayService.displayName(post.getUser()))
+				.activityDate(post.getActivityDate())
+				.createdAt(post.getCreatedAt())
+				.build());
+	}
 
-    @Transactional(readOnly = true)
-    public RecruitmentPostDetailResponse getPostDetail(Long postId) {
-        RecruitmentPost post = recruitmentPostRepository.findByIdWithUser(postId)
+	@Transactional(readOnly = true)
+	public RecruitmentPostDetailResponse getPostDetail(Long postId) {
+		RecruitmentPost post = recruitmentPostRepository.findByIdWithUser(postId)
 			.orElseThrow(() -> new RecruitmentPostNotFoundException(postId));
 
-        List<String> imageUrls = recruitmentPostImageRepository.findByRecruitmentPostId(postId).stream()
+		List<String> imageUrls = recruitmentPostImageRepository.findByRecruitmentPostId(postId).stream()
 			.map(RecruitmentPostImage::getImageUrl)
 			.map(objectStorageRepository::getDownloadUrl)
 			.collect(Collectors.toList());
 
-        return RecruitmentPostDetailResponse.builder()
+		return RecruitmentPostDetailResponse.builder()
 			.postId(post.getId())
 			.title(post.getTitle())
 			.content(post.getContent())
-			.authorNickname(post.getUser().getNickname())
+			.authorNickname(userDisplayService.displayName(post.getUser()))
 			.activityDate(post.getActivityDate())
 			.recruitmentEndDate(post.getRecruitmentEndDate())
 			.createdAt(post.getCreatedAt())
 			.imageUrls(imageUrls)
 			.build();
-    }
+	}
 
-    @Transactional
-    @Retryable(
+	@Transactional
+	@Retryable(
 		retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
 		maxAttempts = 3,
 		backoff = @Backoff(delay = 50)
-    )
-    public RecruitmentPostLikeResponse toggleLike(Long postId, Long userId) {
-        RecruitmentPost post = recruitmentPostRepository.findById(postId)
+	)
+	public RecruitmentPostLikeResponse toggleLike(Long postId, Long userId) {
+		RecruitmentPost post = recruitmentPostRepository.findById(postId)
 			.orElseThrow(() -> new RecruitmentPostNotFoundException(postId));
 
-        User user = userRepository.findById(userId)
+		User user = userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
 
-        Optional<RecruitmentPostLike> existingLike = recruitmentPostLikeRepository
+		Optional<RecruitmentPostLike> existingLike = recruitmentPostLikeRepository
 			.findByUser_IdAndRecruitmentPost_Id(user.getId(), postId);
-        
-        boolean isLiked;
-        if (existingLike.isPresent()) {
-            unlikePost(existingLike.get(), post);
-            isLiked = false;
-        } else {
-            likePost(user, post);
-            isLiked = true;
-        }
-        
-        return buildLikeResponse(isLiked, post);
-    }
-    
-    private void likePost(User user, RecruitmentPost post) {
-        RecruitmentPostLike like = RecruitmentPostLike.builder()
-            .user(user)
-            .recruitmentPost(post)
-            .build();
-            
-        recruitmentPostLikeRepository.save(like);
-        post.increaseLikeCount();
-    }
 
-    private void unlikePost(RecruitmentPostLike existingLike, RecruitmentPost post) {
-        recruitmentPostLikeRepository.delete(existingLike);
-        post.decreaseLikeCount();
-    }
-    
-    private RecruitmentPostLikeResponse buildLikeResponse(boolean isLiked, RecruitmentPost post) {
-        return RecruitmentPostLikeResponse.builder()
+		boolean isLiked;
+		if (existingLike.isPresent()) {
+			unlikePost(existingLike.get(), post);
+			isLiked = false;
+		} else {
+			likePost(user, post);
+			isLiked = true;
+		}
+
+		return buildLikeResponse(isLiked, post);
+	}
+
+	private void likePost(User user, RecruitmentPost post) {
+		RecruitmentPostLike like = RecruitmentPostLike.builder()
+			.user(user)
+			.recruitmentPost(post)
+			.build();
+
+		recruitmentPostLikeRepository.save(like);
+		post.increaseLikeCount();
+	}
+
+	private void unlikePost(RecruitmentPostLike existingLike, RecruitmentPost post) {
+		recruitmentPostLikeRepository.delete(existingLike);
+		post.decreaseLikeCount();
+	}
+
+	private RecruitmentPostLikeResponse buildLikeResponse(boolean isLiked, RecruitmentPost post) {
+		return RecruitmentPostLikeResponse.builder()
 			.liked(isLiked)
 			.likeCount(post.getLikeCount())
 			.build();
-    }            
-    
-    public RecruitmentPostCommentResponse createComment(
-        Long recruitmentPostId, Long userId, RecruitmentPostCommentRequest request, MultipartFile image) {
+	}
 
-        RecruitmentPost recruitmentPost = recruitmentPostRepository.findById(recruitmentPostId)
+	public RecruitmentPostCommentResponse createComment(
+		Long recruitmentPostId, Long userId, RecruitmentPostCommentRequest request, MultipartFile image) {
+
+		RecruitmentPost recruitmentPost = recruitmentPostRepository.findById(recruitmentPostId)
 			.orElseThrow(() -> new RecruitmentPostNotFoundException(recruitmentPostId));
-      
-        User user = userRepository.findById(userId)
+
+		User user = userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
-        
-        RecruitmentPostComment parentComment = null;
-        if (request.getParentCommentId() != null) {
-            Optional<Long> parentCommentIdOptional = Optional.ofNullable(request.getParentCommentId());
-            parentComment = recruitmentPostCommentRepository.findById(parentCommentIdOptional.get())
+
+		RecruitmentPostComment parentComment = null;
+		if (request.getParentCommentId() != null) {
+			Optional<Long> parentCommentIdOptional = Optional.ofNullable(request.getParentCommentId());
+			parentComment = recruitmentPostCommentRepository.findById(parentCommentIdOptional.get())
 				.orElseThrow(CommentNotFoundException::new);
 
-            if (!parentComment.getRecruitmentPost().getId().equals(recruitmentPostId)) {
-                throw new ParentCommentMismatchException();
-            }
-        }
+			if (!parentComment.getRecruitmentPost().getId().equals(recruitmentPostId)) {
+				throw new ParentCommentMismatchException();
+			}
+		}
 
-        String imageUrl = null;
-        if (image != null && !image.isEmpty()) {
-            try {
-                imageUrl = imageUploadService.upload(image, "recruitment-comment");
-            } catch (Exception e) {
-                throw new FileUploadFailException();
-            }
-        }
+		String imageUrl = null;
+		if (image != null && !image.isEmpty()) {
+			try {
+				imageUrl = imageUploadService.upload(image, "recruitment-comment");
+			} catch (Exception e) {
+				throw new FileUploadFailException();
+			}
+		}
 
-        RecruitmentPostComment recruitmentPostComment = RecruitmentPostComment.builder()
+		RecruitmentPostComment recruitmentPostComment = RecruitmentPostComment.builder()
 			.recruitmentPost(recruitmentPost)
 			.user(user)
 			.content(request.getContent())
@@ -248,93 +249,98 @@ public class RecruitmentPostService {
 			.parentComment(parentComment)
 			.build();
 
-        recruitmentPostCommentRepository.save(recruitmentPostComment);
+		recruitmentPostCommentRepository.save(recruitmentPostComment);
 
-        recruitmentPost.increaseCommentCount();
+		recruitmentPost.increaseCommentCount();
 
-        return RecruitmentPostCommentResponse.builder()
+		return RecruitmentPostCommentResponse.builder()
 			.id(recruitmentPostComment.getId())
 			.userId(user.getId())
-			.nickname(user.getNickname())
+			.nickname(userDisplayService.displayName(user))
 			.content(recruitmentPostComment.getContent())
 			.createdAt(recruitmentPostComment.getCreatedAt())
 			.build();
-    }
+	}
 
-    @Transactional
-    @Retryable(
-        retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
-        maxAttempts = 3,
-        backoff = @Backoff(delay = 50)
-    )
-    public void deleteComment(Long commentId, Long userId) {
-        RecruitmentPostComment comment = recruitmentPostCommentRepository.findById(commentId)
-            .orElseThrow(() -> new CommentNotFoundException());
+	@Transactional
+	@Retryable(
+		retryFor = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 50)
+	)
+	public void deleteComment(Long commentId, Long userId) {
+		RecruitmentPostComment comment = recruitmentPostCommentRepository.findById(commentId)
+			.orElseThrow(() -> new CommentNotFoundException());
 
-        if (!comment.getUser().getId().equals(userId)) {
-            throw new AccessDeniedException();
-        }
+		if (!comment.getUser().getId().equals(userId)) {
+			throw new AccessDeniedException();
+		}
 
-        List<RecruitmentPostComment> replies = recruitmentPostCommentRepository.findByParentCommentIdIn(Collections.singletonList(commentId));
-        if (replies.isEmpty()) {
-            comment.getRecruitmentPost().decreaseCommentCount();
-            recruitmentPostCommentRepository.delete(comment);
-        } else {
-            comment.setContent("삭제된 댓글입니다.");
-            comment.setImageUrl(null); 
-        }
-    }
-  
-    @Transactional(readOnly = true)
-    public Slice<RecruitmentPostCommentResponse> getComments(Long postId, Long lastId, int size) {
-        Slice<RecruitmentPostComment> topLevelCommentsPage;
+		List<RecruitmentPostComment> replies = recruitmentPostCommentRepository.findByParentCommentIdIn(
+			Collections.singletonList(commentId));
+		if (replies.isEmpty()) {
+			comment.getRecruitmentPost().decreaseCommentCount();
+			recruitmentPostCommentRepository.delete(comment);
+		} else {
+			comment.setContent("삭제된 댓글입니다.");
+			comment.setImageUrl(null);
+		}
+	}
 
-        Pageable pageable = Pageable.ofSize(size);
+	@Transactional(readOnly = true)
+	public Slice<RecruitmentPostCommentResponse> getComments(Long postId, Long lastId, int size) {
+		Slice<RecruitmentPostComment> topLevelCommentsPage;
 
+		Pageable pageable = Pageable.ofSize(size);
 
-        if (lastId == null) {
-            topLevelCommentsPage =
-            recruitmentPostCommentRepository.findByRecruitmentPost_IdAndParentCommentIsNullOrderByIdDesc(postId, pageable);
-        } else {
-            topLevelCommentsPage =
-            recruitmentPostCommentRepository.findByRecruitmentPost_IdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(postId, lastId, pageable);
-        }
+		if (lastId == null) {
+			topLevelCommentsPage =
+				recruitmentPostCommentRepository.findByRecruitmentPost_IdAndParentCommentIsNullOrderByIdDesc(postId,
+					pageable);
+		} else {
+			topLevelCommentsPage =
+				recruitmentPostCommentRepository.findByRecruitmentPost_IdAndParentCommentIsNullAndIdLessThanOrderByIdDesc(
+					postId, lastId, pageable);
+		}
 
-        if (topLevelCommentsPage.isEmpty()) {
-            return new SliceImpl<>(Collections.emptyList(), pageable, false);
-        }
+		if (topLevelCommentsPage.isEmpty()) {
+			return new SliceImpl<>(Collections.emptyList(), pageable, false);
+		}
 
-        List<Long> topCommentIds = topLevelCommentsPage.getContent().stream()
-            .map(RecruitmentPostComment::getId)
-            .collect(Collectors.toList());
+		List<Long> topCommentIds = topLevelCommentsPage.getContent().stream()
+			.map(RecruitmentPostComment::getId)
+			.collect(Collectors.toList());
 
-        List<RecruitmentPostComment> allReplies = recruitmentPostCommentRepository.findByParentCommentIdIn(topCommentIds);
+		List<RecruitmentPostComment> allReplies = recruitmentPostCommentRepository.findByParentCommentIdIn(
+			topCommentIds);
 
-        Map<Long, List<RecruitmentPostComment>> repliesByParentId = allReplies.stream()
-            .collect(Collectors.groupingBy(comment -> comment.getParentComment().getId()));
+		Map<Long, List<RecruitmentPostComment>> repliesByParentId = allReplies.stream()
+			.collect(Collectors.groupingBy(comment -> comment.getParentComment().getId()));
 
-        return topLevelCommentsPage.map(topComment -> {
-        List<RecruitmentPostComment> replies = repliesByParentId.getOrDefault(topComment.getId(), Collections.emptyList());
+		return topLevelCommentsPage.map(topComment -> {
+			List<RecruitmentPostComment> replies = repliesByParentId.getOrDefault(topComment.getId(),
+				Collections.emptyList());
 
-        return mapToCommentResponse(topComment, replies);
-        });
-    }
+			return mapToCommentResponse(topComment, replies);
+		});
+	}
 
-    private RecruitmentPostCommentResponse mapToCommentResponse(
-        RecruitmentPostComment comment, List<RecruitmentPostComment> replies) {
+	private RecruitmentPostCommentResponse mapToCommentResponse(
+		RecruitmentPostComment comment, List<RecruitmentPostComment> replies) {
 
-        List<RecruitmentPostCommentResponse> replyResponses = replies.stream()  
-            .map(reply -> mapToCommentResponse(reply, Collections.emptyList()))  
-            .collect(Collectors.toList());  
+		List<RecruitmentPostCommentResponse> replyResponses = replies.stream()
+			.map(reply -> mapToCommentResponse(reply, Collections.emptyList()))
+			.collect(Collectors.toList());
 
-        return RecruitmentPostCommentResponse.builder()
-            .id(comment.getId())
-            .userId(comment.getUser().getId())
-            .nickname(comment.getUser().getNickname())
-            .content(comment.getContent())
-            .imageUrl(comment.getImageUrl() != null ? objectStorageRepository.getDownloadUrl(comment.getImageUrl()) : null)
-            .createdAt(comment.getCreatedAt())
-            .replies(replyResponses)
-            .build();
-    }
+		return RecruitmentPostCommentResponse.builder()
+			.id(comment.getId())
+			.userId(comment.getUser().getId())
+			.nickname(userDisplayService.displayName(comment.getUser()))
+			.content(comment.getContent())
+			.imageUrl(
+				comment.getImageUrl() != null ? objectStorageRepository.getDownloadUrl(comment.getImageUrl()) : null)
+			.createdAt(comment.getCreatedAt())
+			.replies(replyResponses)
+			.build();
+	}
 }

--- a/src/main/java/kr/bi/greenmate/service/StorageDeleteListener.java
+++ b/src/main/java/kr/bi/greenmate/service/StorageDeleteListener.java
@@ -1,0 +1,35 @@
+package kr.bi.greenmate.service;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.bi.greenmate.repository.ObjectStorageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StorageDeleteListener {
+
+	private final ObjectStorageRepository storage;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 200))
+	public void on(ImagesToDeleteEvent e) {
+		for (String key : e.keys()) {
+			try {
+				if (key != null)
+					storage.delete(key);
+			} catch (Exception ex) {
+				log.warn("object storage delete failed key={}", key, ex);
+				throw ex;
+			}
+		}
+	}
+}

--- a/src/main/java/kr/bi/greenmate/service/UserDisplayService.java
+++ b/src/main/java/kr/bi/greenmate/service/UserDisplayService.java
@@ -1,0 +1,25 @@
+package kr.bi.greenmate.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import kr.bi.greenmate.entity.User;
+
+@Component
+public class UserDisplayService {
+
+	@Value("${app.default-profile-image-url}")
+	private String defaultProfileImageUrl;
+
+	public String displayName(User user) {
+		if (user == null || user.getDeletedAt() != null)
+			return "탈퇴한 회원";
+		return user.getNickname();
+	}
+
+	public String profileImage(User user) {
+		if (user == null || user.getDeletedAt() != null)
+			return defaultProfileImageUrl;
+		return user.getProfileImageUrl();
+	}
+}

--- a/src/main/resources/application-database.yml
+++ b/src/main/resources/application-database.yml
@@ -16,3 +16,5 @@ logging:
   level:
     org:
       hibernate: info
+app:
+  default-profile-image-url: "https://test.image.png"

--- a/src/main/resources/application-database.yml
+++ b/src/main/resources/application-database.yml
@@ -17,4 +17,4 @@ logging:
     org:
       hibernate: info
 app:
-  default-profile-image-url: "https://test.image.png"
+  default-profile-image-url: "https://green-mate-t1-cdn.jayden-bin.cc/profile/default/default-profile.png"


### PR DESCRIPTION
### 개요
회원 탈퇴 API 기능을 추가했습니다.
- Soft Delete 방식을 사용했습니다.
- 탈퇴한 사용자의 컨텐츠(글, 댓글)와 지표(좋아요, 조회수)는 그대로 유지합니다.
- 탈퇴한 사용자의 닉네임, 이메일을 변경하여 새로운 가입 시에 사용할 수 있도록 합니다.
(기존 닉네임 길이 제한을 지키기 위해 탈퇴시 이메일/닉네임을 `d_userId` 형식으로 변경합니다.)

### 변경사항
- 회원탈퇴 API 엔드포인트 추가
- 유저 엔티티 `deletedAt` 필드 추가
- `UserDisplayService` 추가 
(탈퇴한 회원의 닉네임을 "탈퇴한 회원", 프로필 이미지를 기본 이미지로 변환)
- 커뮤니티/모집 글, 댓글 reponse 마스킹

### 리뷰어에게 하고 싶은 말
```
app:
  default-profile-image-url: "https://test.image.png"
```
`application-database.yml`에 테스트용으로 위와 같은 추가했습니다. 오브젝트 스토리지에 실제 이미지 업로드 하고 경로 적용하면 될까요?