### PR TITLE
TEAM1-81 feat: 커뮤니티 글 삭제 API 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -117,5 +118,18 @@ public class CommunityPostController {
 			communityPostService.getComments(postId, lastCommentId, size);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/{postId}/comments/{commentId}")
+	@Operation(summary = "커뮤니티 댓글 삭제", description = "특정 커뮤니티 글의 댓글을 삭제합니다.")
+	public ResponseEntity<Void> deleteComment(
+		@Parameter(description = "댓글을 삭제할 커뮤니티 글 ID", example = "123")
+		@PathVariable long postId,
+		@Parameter(description = "삭제할 댓글 ID", example = "456")
+		@PathVariable long commentId,
+		@AuthenticationPrincipal User user) {
+
+		communityPostService.deleteComment(postId, commentId, user);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -120,16 +120,14 @@ public class CommunityPostController {
 		return ResponseEntity.ok(response);
 	}
 
-	@DeleteMapping("/{postId}/comments/{commentId}")
+	@DeleteMapping("/comments/{commentId}")
 	@Operation(summary = "커뮤니티 댓글 삭제", description = "특정 커뮤니티 글의 댓글을 삭제합니다.")
 	public ResponseEntity<Void> deleteComment(
-		@Parameter(description = "댓글을 삭제할 커뮤니티 글 ID", example = "123")
-		@PathVariable long postId,
 		@Parameter(description = "삭제할 댓글 ID", example = "456")
 		@PathVariable long commentId,
 		@AuthenticationPrincipal User user) {
 
-		communityPostService.deleteComment(postId, commentId, user);
+		communityPostService.deleteComment(commentId, user);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -120,6 +120,17 @@ public class CommunityPostController {
 		return ResponseEntity.ok(response);
 	}
 
+	@DeleteMapping("/{postId}")
+	@Operation(summary = "커뮤니티 글 삭제", description = "특정 커뮤니티 글을 삭제합니다.")
+	public ResponseEntity<Void> deletePost(
+		@Parameter(description = "삭제할 게시글 ID", example = "123")
+		@PathVariable long postId,
+		@AuthenticationPrincipal User user) {
+
+		communityPostService.deletePost(postId, user);
+		return ResponseEntity.noContent().build();
+	}
+
 	@DeleteMapping("/comments/{commentId}")
 	@Operation(summary = "커뮤니티 댓글 삭제", description = "특정 커뮤니티 글의 댓글을 삭제합니다.")
 	public ResponseEntity<Void> deleteComment(

--- a/src/main/java/kr/bi/greenmate/entity/CommunityPost.java
+++ b/src/main/java/kr/bi/greenmate/entity/CommunityPost.java
@@ -79,4 +79,8 @@ public class CommunityPost extends BaseTimeEntity {
 	public void incrementCommentCount() {
 		this.commentCount++;
 	}
+
+	public void decrementCommentCount() {
+		this.commentCount--;
+	}
 }

--- a/src/main/java/kr/bi/greenmate/exception/ErrorCode.java
+++ b/src/main/java/kr/bi/greenmate/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
 
 	VIEW_COUNT_FLUSH_FAIL("500-03", "조회수 동기화 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 	VIEW_COUNT_PERSIST_FAIL("500-04", "조회수 데이터베이스 반영 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-	REDIS_CONNECTION_FAIL("500-05", "Redis 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+	REDIS_CONNECTION_FAIL("500-05", "Redis 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+	POST_DELETION_FAILED("500-06", "게시글 삭제 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/kr/bi/greenmate/exception/error/PostDeletionException.java
+++ b/src/main/java/kr/bi/greenmate/exception/error/PostDeletionException.java
@@ -1,0 +1,10 @@
+package kr.bi.greenmate.exception.error;
+
+import kr.bi.greenmate.exception.BusinessException;
+import kr.bi.greenmate.exception.ErrorCode;
+
+public class PostDeletionException extends BusinessException {
+	public PostDeletionException() {
+		super(ErrorCode.POST_DELETION_FAILED);
+	}
+}

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.bi.greenmate.entity.CommunityPostComment;
 
@@ -18,4 +21,10 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
+
+	@Modifying
+	@Query("DELETE FROM CommunityPostComment c WHERE c.id = :commentId AND c.parent.id = :postId AND c.user.id = :userId")
+	int deleteByIdAndParentIdAndUserId(@Param("commentId") Long commentId,
+		@Param("postId") Long postId,
+		@Param("userId") Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -22,5 +22,7 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
-	long deleteByIdAndParent_IdAndUser_Id(Long commentId, Long postId, Long userId);
+	Optional<Long> findParentIdById(Long commentId);
+
+	long deleteByIdAndParentIdAndUserId(Long commentId, Long postId, Long id);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -22,9 +22,5 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
-	@Modifying
-	@Query("DELETE FROM CommunityPostComment c WHERE c.id = :commentId AND c.parent.id = :postId AND c.user.id = :userId")
-	int deleteByIdAndParentIdAndUserId(@Param("commentId") Long commentId,
-		@Param("postId") Long postId,
-		@Param("userId") Long userId);
+	int deleteByIdAndParent_IdAndUser_Id(Long commentId, Long postId, Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -22,5 +22,5 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
-	int deleteByIdAndParent_IdAndUser_Id(Long commentId, Long postId, Long userId);
+	long deleteByIdAndParent_IdAndUser_Id(Long commentId, Long postId, Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -29,4 +29,6 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	@Modifying
 	@Query("UPDATE CommunityPost p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId AND p.commentCount > 0")
 	void decrementCommentCount(@Param("postId") Long postId);
+
+	long deleteByIdAndUser_Id(Long postId, Long id);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -42,4 +42,8 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	@Modifying
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
+
+	@Modifying
+	@Query("UPDATE CommunityPost p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId AND p.commentCount > 0")
+	int decrementCommentCount(@Param("postId") Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -35,10 +35,6 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 		""")
 	Slice<CommunityPost> findNextPage(@Param("lastPostId") Long lastPostId, Pageable pageable);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("UPDATE CommunityPost p SET p.viewCount = p.viewCount + :delta WHERE p.id = :postId")
-	int incrementViewCountBy(@Param("postId") Long postId, @Param("delta") long delta);
-
 	@Modifying
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -13,33 +13,20 @@ import org.springframework.data.repository.query.Param;
 import kr.bi.greenmate.entity.CommunityPost;
 
 public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long> {
-	@Query("""
-		SELECT p 
-		FROM CommunityPost p
-		JOIN FETCH p.user
-		WHERE p.id = :postId""")
-	Optional<CommunityPost> findByIdWithUserAndImages(@Param("postId") Long postId);
+	@EntityGraph(attributePaths = {"user", "images"})
+	Optional<CommunityPost> findById(Long id);
 
 	@EntityGraph(attributePaths = {"user"})
-	@Query("""
-		SELECT p FROM CommunityPost p
-		ORDER BY p.id DESC
-		""")
-	Slice<CommunityPost> findFirstPage(Pageable pageable);
+	Slice<CommunityPost> findAllByOrderByIdDesc(Pageable pageable);
 
 	@EntityGraph(attributePaths = {"user"})
-	@Query("""
-		SELECT p FROM CommunityPost p
-		WHERE p.id < :lastPostId
-		ORDER BY p.id DESC
-		""")
-	Slice<CommunityPost> findNextPage(@Param("lastPostId") Long lastPostId, Pageable pageable);
+	Slice<CommunityPost> findByIdLessThanOrderByIdDesc(Long lastPostId, Pageable pageable);
 
 	@Modifying
 	@Query("update CommunityPost p set p.viewCount = p.viewCount + :delta where p.id = :id")
-	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
+	void incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
 	@Modifying
 	@Query("UPDATE CommunityPost p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId AND p.commentCount > 0")
-	int decrementCommentCount(@Param("postId") Long postId);
+	void decrementCommentCount(@Param("postId") Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -322,10 +322,10 @@ public class CommunityPostService {
 
 	@Transactional
 	public void deleteComment(Long postId, Long commentId, User user) {
-		int deletedCount = communityPostCommentRepository
+		long deleted = communityPostCommentRepository
 			.deleteByIdAndParent_IdAndUser_Id(commentId, postId, user.getId());
 
-		if (deletedCount == 0) {
+		if (deleted == 0) {
 			if (!communityPostCommentRepository.existsById(commentId)) {
 				throw new CommentNotFoundException();
 			}

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -321,11 +321,14 @@ public class CommunityPostService {
 	}
 
 	@Transactional
-	public void deleteComment(Long postId, Long commentId, User user) {
-		long deleted = communityPostCommentRepository
-			.deleteByIdAndParent_IdAndUser_Id(commentId, postId, user.getId());
+	public void deleteComment(Long commentId, User user) {
+		Long postId = communityPostCommentRepository.findParentIdById(commentId)
+			.orElseThrow(CommentNotFoundException::new);
 
-		if (deleted == 0) {
+		long deletedCount = communityPostCommentRepository
+			.deleteByIdAndParentIdAndUserId(commentId, postId, user.getId());
+
+		if (deletedCount == 0) {
 			if (!communityPostCommentRepository.existsById(commentId)) {
 				throw new CommentNotFoundException();
 			}

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -330,9 +330,13 @@ public class CommunityPostService {
 			throw new AccessDeniedException();
 		}
 
-		communityPostCommentRepository.delete(comment);
+		int deletedCount = communityPostCommentRepository
+			.deleteByIdAndParentIdAndUserId(commentId, postId, user.getId());
 
-		CommunityPost post = comment.getParent();
-		post.decrementCommentCount();
+		if (deletedCount == 0) {
+			throw new CommentNotFoundException();
+		}
+
+		communityPostRepository.decrementCommentCount(postId);
 	}
 }

--- a/src/main/java/kr/bi/greenmate/service/ImagesToDeleteEvent.java
+++ b/src/main/java/kr/bi/greenmate/service/ImagesToDeleteEvent.java
@@ -1,0 +1,6 @@
+package kr.bi.greenmate.service;
+
+import java.util.List;
+
+public record ImagesToDeleteEvent(List<String> keys) {
+}

--- a/src/main/java/kr/bi/greenmate/service/StorageDeleteListener.java
+++ b/src/main/java/kr/bi/greenmate/service/StorageDeleteListener.java
@@ -1,0 +1,35 @@
+package kr.bi.greenmate.service;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.bi.greenmate.repository.ObjectStorageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StorageDeleteListener {
+
+	private final ObjectStorageRepository storage;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 200))
+	public void on(ImagesToDeleteEvent e) {
+		for (String key : e.keys()) {
+			try {
+				if (key != null)
+					storage.delete(key);
+			} catch (Exception ex) {
+				log.warn("object storage delete failed key={}", key, ex);
+				throw ex;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### 개요
커뮤니티 글 삭제 API 기능을 추가했습니다.

### 변경사항
- 컨트롤러: 커뮤니티 글 삭제 엔드포인트 추가
- 서비스: `deletePost() `메서드 구현

### 리뷰어에게 하고 싶은 말
사용자 탈퇴 API에 사용한 이벤트 리스터 사용하여 업로드 이미지 삭제를 구현했습니다.