### PR TITLE
TEAM1-81 feat: 커뮤니티 글 삭제 API 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -117,5 +118,16 @@ public class CommunityPostController {
 			communityPostService.getComments(postId, lastCommentId, size);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/{postId}")
+	@Operation(summary = "커뮤니티 글 삭제", description = "특정 커뮤니티 글을 삭제합니다. 관련된 댓글, 좋아요, 이미지가 모두 함께 삭제됩니다.")
+	public ResponseEntity<Void> deletePost(
+		@Parameter(description = "삭제할 게시글 ID", example = "123")
+		@PathVariable Long postId,
+		@AuthenticationPrincipal User user) {
+
+		communityPostService.deletePost(postId, user);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -6,9 +6,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import jakarta.persistence.LockModeType;
 import kr.bi.greenmate.entity.CommunityPostComment;
 
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostComment, Long> {
@@ -22,4 +24,13 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
 	void deleteByUser_Id(Long userId);
+
+	@Query("select c.imageUrl from CommunityPostComment c where c.parent.id = :postId and c.imageUrl is not null")
+	List<String> findImageUrlsByPostId(Long postId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<CommunityPostComment> findAllByParentId(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	void deleteByParentId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
@@ -3,9 +3,11 @@ package kr.bi.greenmate.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import kr.bi.greenmate.entity.CommunityPostImage;
 
 public interface CommunityPostImageRepository extends JpaRepository<CommunityPostImage, Long> {
@@ -20,4 +22,7 @@ public interface CommunityPostImageRepository extends JpaRepository<CommunityPos
 		  where p.user.id = :userId
 		""")
 	List<String> findImageKeysByOwner(Long userId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<CommunityPostImage> findByCommunityPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -24,5 +25,8 @@ public interface CommunityPostImageRepository extends JpaRepository<CommunityPos
 	List<String> findImageKeysByOwner(Long userId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	List<CommunityPostImage> findByCommunityPostId(Long postId);
+	List<CommunityPostImage> findAllByCommunityPostId(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	void deleteByCommunityPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostLikeRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostLikeRepository.java
@@ -4,9 +4,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import kr.bi.greenmate.entity.CommunityPost;
 import kr.bi.greenmate.entity.CommunityPostLike;
 
@@ -24,4 +27,10 @@ public interface CommunityPostLikeRepository extends JpaRepository<CommunityPost
 	List<Long> findLikedPostIdsByUserIdAndPosts(
 		@Param("userId") Long userId,
 		@Param("posts") List<CommunityPost> posts);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<CommunityPostLike> findAllByCommunityPostId(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	void deleteByCommunityPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -42,4 +42,7 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
 	void deleteByUser_Id(Long userId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<CommunityPost> findWithLockById(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -42,7 +42,4 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
 	void deleteByUser_Id(Long userId);
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	Optional<CommunityPost> findWithLockById(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import kr.bi.greenmate.entity.CommunityPost;
 
 public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long> {
@@ -40,4 +42,7 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
 	void deleteByUser_Id(Long userId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<CommunityPost> findWithLockById(Long postId);
 }


### PR DESCRIPTION
### 개요
커뮤니티 글 삭제 API 추가
비관적 락을 적용했습니다.

### 변경사항
- 컨트롤러: 커뮤니티 글 삭제 엔드포인트 추가
- 서비스: `deletePost` 메서드 추가
   - 게시글과 이미지에 대해 비관적 락을 적용하여 동시 접근을 막을 수 있도록 했습니다.

### 리뷰어에게 하고 싶은 말
감사합니다