### PR TITLE
TEAM1-54 feat: 유저 프로필을 위한 사용자가 작성한 커뮤니티 글 리스트 조회 API 추가

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/CommunityPostController.java
@@ -118,4 +118,21 @@ public class CommunityPostController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@GetMapping("/{userId}/posts")
+	@Operation(summary = "사용자 작성 커뮤니티 글 목록 조회", description = "특정 사용자가 작성한 커뮤니티 글 목록을 조회합니다.")
+	public ResponseEntity<KeysetSliceResponse<CommunityPostListResponse>> getUserPosts(
+		@AuthenticationPrincipal User user,
+		@Parameter(description = "조회할 사용자 ID", example = "123")
+		@PathVariable Long userId,
+		@Parameter(description = "마지막으로 조회한 게시글 ID (첫 페이지 조회 시 생략 가능)", example = "100")
+		@RequestParam(required = false) Long lastPostId,
+		@Parameter(description = "한 번에 조회할 게시글 개수", example = "10")
+		@RequestParam(defaultValue = "10") int size) {
+
+		KeysetSliceResponse<CommunityPostListResponse> response =
+			communityPostService.getUserPosts(user, userId, lastPostId, size);
+		
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -40,4 +40,10 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 	int incrementViewCountBy(@Param("id") long id, @Param("delta") long delta);
 
 	void deleteByUser_Id(Long userId);
+
+	@EntityGraph(attributePaths = {"user"})
+	Slice<CommunityPost> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"user"})
+	Slice<CommunityPost> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastPostId, Pageable pageable);
 }

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -318,4 +318,45 @@ public class CommunityPostService {
 
 		return new KeysetSliceResponse<>(content, hasNext, newLastId);
 	}
+
+	@Transactional(readOnly = true)
+	public KeysetSliceResponse<CommunityPostListResponse> getUserPosts(User currentUser, Long userId, Long lastPostId,
+		int size) {
+
+		Pageable pageable = PageRequest.of(0, size);
+
+		Slice<CommunityPost> slice;
+		if (lastPostId == null) {
+			slice = communityPostRepository.findByUserIdOrderByIdDesc(userId, pageable);
+		} else {
+			slice = communityPostRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastPostId, pageable);
+		}
+
+		List<CommunityPost> posts = slice.getContent();
+
+		Set<Long> likedPostIds;
+		if (currentUser != null && !posts.isEmpty()) {
+			likedPostIds = new HashSet<>(
+				communityPostLikeRepository.findLikedPostIdsByUserIdAndPosts(currentUser.getId(), posts));
+		} else {
+			likedPostIds = Collections.emptySet();
+		}
+
+		List<CommunityPostListResponse> content = posts.stream()
+			.map(post -> CommunityPostListResponse.builder()
+				.postId(post.getId())
+				.title(post.getTitle())
+				.authorNickname(userDisplayService.displayName(post.getUser()))
+				.createdAt(post.getCreatedAt())
+				.isLikedByUser(likedPostIds.contains(post.getId()))
+				.likeCount(post.getLikeCount())
+				.viewCount(post.getViewCount())
+				.commentCount(post.getCommentCount())
+				.build())
+			.toList();
+
+		Long newLastId = content.isEmpty() ? null : content.get(content.size() - 1).getPostId();
+
+		return new KeysetSliceResponse<>(content, slice.hasNext(), newLastId);
+	}
 }


### PR DESCRIPTION
### 개요
유저 프로필 조회 시 유저가 작성한 게시글 목록을 조회하는 기능입니다.

### 변경사항
- 유저가 작성한 글 리스트 조회 API 추가` /{userId}/posts`
- `getUserPost` 메서드 추가
- `FetchJoin`으로 N+1 문제 해결

### 리뷰어에게 하고 싶은 말
커뮤니티 글 리스트를 조회하는 getPosts 메서드와 유사한 방식으로 작성했습니다.

멘토님이 회의 때 이 업무에 대해 기대 중이라고 하셨는데 뭔가 추가적인 기능이 포함되었어야 했나 싶어서 불안하네요 ㅜㅜ