### PR TITLE
TEAM1- 99 fix: 환경 활동 댓글 @AuthenticationPrincipal 타입 불일치 해결

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/RecruitmentPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/RecruitmentPostController.java
@@ -91,9 +91,9 @@ public class RecruitmentPostController {
 	@Operation(summary = "모집글 좋아요 토글", description = "모집글에 좋아요를 누르거나 취소합니다.")
 	public ResponseEntity<RecruitmentPostLikeResponse> toggleLike(
 		@PathVariable Long postId,
-		@AuthenticationPrincipal Long userId) {
+		@AuthenticationPrincipal User user) {
 
-		RecruitmentPostLikeResponse response = recruitmentPostService.toggleLike(postId, userId);
+		RecruitmentPostLikeResponse response = recruitmentPostService.toggleLike(postId, user.getId());
 
 		return ResponseEntity.ok(response);
 	}
@@ -104,9 +104,9 @@ public class RecruitmentPostController {
 		@PathVariable Long postId,
 		@RequestPart @Valid RecruitmentPostCommentRequest request,
 		@RequestPart(required = false) MultipartFile image,
-		@AuthenticationPrincipal Long userId) {
+		@AuthenticationPrincipal User user) {
 
-		RecruitmentPostCommentResponse response = recruitmentPostService.createComment(postId, userId, request, image);
+		RecruitmentPostCommentResponse response = recruitmentPostService.createComment(postId, user.getId(), request, image);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
@@ -130,8 +130,8 @@ public class RecruitmentPostController {
     )
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long commentId,
-            @AuthenticationPrincipal Long userId) {
-        recruitmentPostService.deleteComment(commentId, userId);
+            @AuthenticationPrincipal User user) {
+        recruitmentPostService.deleteComment(commentId, user.getId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 


### PR DESCRIPTION
### 개요
JWT 필터에서 설정한 Principal 타입과 환경 활동 댓글 컨트롤러에서 받는 타입이 달라 유저ID를 null로 주입받는 에러를 수정했습니다.

### 변경사항
- `@AuthenticationPrincipal` 타입을 `User` 객체로 변경하였습니다.


### 리뷰어에게 하고 싶은 말
다음주도 화이팅입니다!