### PR TITLE
TEAM1-98 feat: 댓글 삭제 / 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/kr/bi/greenmate/controller/RecruitmentPostController.java
+++ b/src/main/java/kr/bi/greenmate/controller/RecruitmentPostController.java
@@ -58,17 +58,17 @@ public class RecruitmentPostController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-  @DeleteMapping("/{postId}")
-  @Operation(summary = "모집글 삭제", description = "특정 ID의 모집글을 삭제합니다.")
-  public ResponseEntity<Void> deleteRecruitmentPost(
-    @PathVariable Long postId,
-    @AuthenticationPrincipal User user) {
+	@DeleteMapping("/{postId}")
+	@Operation(summary = "모집글 삭제", description = "특정 ID의 모집글을 삭제합니다.")
+	public ResponseEntity<Void> deleteRecruitmentPost(
+		@PathVariable Long postId,
+		@AuthenticationPrincipal User user) {
 
-    recruitmentPostService.deleteRecruitmentPost(postId, user.getId());
+		recruitmentPostService.deleteRecruitmentPost(postId, user.getId());
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-  }
-  
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
 	@GetMapping
 	@Operation(summary = "모집글 목록 조회", description = "환경활동 모집글 목록을 조회합니다.")
 	public ResponseEntity<Page<RecruitmentPostListResponse>> getRecruitmentPostList(
@@ -91,9 +91,9 @@ public class RecruitmentPostController {
 	@Operation(summary = "모집글 좋아요 토글", description = "모집글에 좋아요를 누르거나 취소합니다.")
 	public ResponseEntity<RecruitmentPostLikeResponse> toggleLike(
 		@PathVariable Long postId,
-		@AuthenticationPrincipal Long userId) {
+		@AuthenticationPrincipal User user) {
 
-		RecruitmentPostLikeResponse response = recruitmentPostService.toggleLike(postId, userId);
+		RecruitmentPostLikeResponse response = recruitmentPostService.toggleLike(postId, user.getId());
 
 		return ResponseEntity.ok(response);
 	}
@@ -104,46 +104,48 @@ public class RecruitmentPostController {
 		@PathVariable Long postId,
 		@RequestPart @Valid RecruitmentPostCommentRequest request,
 		@RequestPart(required = false) MultipartFile image,
-		@AuthenticationPrincipal Long userId) {
+		@AuthenticationPrincipal User user) {
 
-		RecruitmentPostCommentResponse response = recruitmentPostService.createComment(postId, userId, request, image);
+		RecruitmentPostCommentResponse response = recruitmentPostService.createComment(postId, user.getId(), request,
+			image);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-    @GetMapping("/{postId}/comments")
-    @Operation(summary = "모집글 댓글 목록 조회", description = "특정 모집글의 댓글 목록을 무한 스크롤로 조회합니다.")
-    public ResponseEntity<Slice<RecruitmentPostCommentResponse>> getComments(
-        @PathVariable @Min(1) Long postId,
-        @RequestParam(required = false) @Min(1) Long lastId,
-        @RequestParam(defaultValue = "10") @Min(1) int size) {
+	@GetMapping("/{postId}/comments")
+	@Operation(summary = "모집글 댓글 목록 조회", description = "특정 모집글의 댓글 목록을 무한 스크롤로 조회합니다.")
+	public ResponseEntity<Slice<RecruitmentPostCommentResponse>> getComments(
+		@PathVariable @Min(1) Long postId,
+		@RequestParam(required = false) @Min(1) Long lastId,
+		@RequestParam(defaultValue = "10") @Min(1) int size) {
 
-        Slice<RecruitmentPostCommentResponse> comments = recruitmentPostService.getComments(postId, lastId, size);
-        
-        return ResponseEntity.ok(comments);
-    }
+		Slice<RecruitmentPostCommentResponse> comments = recruitmentPostService.getComments(postId, lastId, size);
 
-    @DeleteMapping("/comments/{commentId}")
-    @Operation(
-            summary = "모집글 댓글 삭제",
-            description = "특정 ID의 댓글을 삭제합니다."
-    )
-    public ResponseEntity<Void> deleteComment(
-            @PathVariable Long commentId,
-            @AuthenticationPrincipal Long userId) {
-        recruitmentPostService.deleteComment(commentId, userId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
+		return ResponseEntity.ok(comments);
+	}
+
+	@DeleteMapping("/comments/{commentId}")
+	@Operation(
+		summary = "모집글 댓글 삭제",
+		description = "특정 ID의 댓글을 삭제합니다."
+	)
+	public ResponseEntity<Void> deleteComment(
+		@PathVariable Long commentId,
+		@AuthenticationPrincipal User user) {
+		recruitmentPostService.deleteComment(commentId, user.getId());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
 
 	@GetMapping("/participated")
-    @Operation(summary = "사용자가 참여 신청한 모집글 목록 조회", description = "현재 로그인된 사용자가 참여 신청한 환경활동 모집글 목록을 조회합니다.")
-    public ResponseEntity<Slice<RecruitmentPostListResponse>> getParticipatedPosts(
-        @AuthenticationPrincipal User user,
-        @RequestParam(required = false) Long lastId,
-        @PageableDefault(page = 0, size = 10) Pageable pageable) {
+	@Operation(summary = "사용자가 참여 신청한 모집글 목록 조회", description = "현재 로그인된 사용자가 참여 신청한 환경활동 모집글 목록을 조회합니다.")
+	public ResponseEntity<Slice<RecruitmentPostListResponse>> getParticipatedPosts(
+		@AuthenticationPrincipal User user,
+		@RequestParam(required = false) Long lastId,
+		@PageableDefault(page = 0, size = 10) Pageable pageable) {
 
-        Slice<RecruitmentPostListResponse> posts = recruitmentPostService.getParticipatedPostsByUserId(user.getId(), lastId, pageable);
-        
-        return ResponseEntity.ok(posts);
-    }
+		Slice<RecruitmentPostListResponse> posts = recruitmentPostService.getParticipatedPostsByUserId(user.getId(),
+			lastId, pageable);
+
+		return ResponseEntity.ok(posts);
+	}
 }

--- a/src/main/java/kr/bi/greenmate/entity/CommunityPostComment.java
+++ b/src/main/java/kr/bi/greenmate/entity/CommunityPostComment.java
@@ -1,5 +1,7 @@
 package kr.bi.greenmate.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,13 +10,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
@@ -44,7 +44,19 @@ public class CommunityPostComment extends BaseTimeEntity {
 	@Column(length = 50)
 	private String imageUrl;
 
+	@Column(nullable = false)
+	@Builder.Default
+	private boolean deleted = false;
+
+	@Column
+	private LocalDateTime deletedAt;
+
 	public void markAsDeleted() {
+		if (this.deleted) {
+			return;
+		}
+		this.deleted = true;
+		this.deletedAt = LocalDateTime.now();
 		this.content = "삭제된 댓글입니다.";
 		this.imageUrl = null;
 	}

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostCommentRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,26 +25,17 @@ public interface CommunityPostCommentRepository extends JpaRepository<CommunityP
 	@EntityGraph(attributePaths = "user")
 	List<CommunityPostComment> findByParent_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastId, Pageable pageable);
 
-	void deleteByUser_Id(Long userId);
-
 	@Query("select c.imageUrl from CommunityPostComment c where c.parent.id = :postId and c.imageUrl is not null")
 	List<String> findImageUrlsByPostId(@Param("postId") Long postId);
 
 	@Query("select c.imageUrl from CommunityPostComment c where c.user.id = :userId and c.imageUrl is not null")
 	List<String> findImageUrlsByUserId(@Param("userId") Long userId);
 
-	@Modifying(clearAutomatically = true)
-	@Query("update CommunityPostComment c set c.deleted = true, c.deletedAt = CURRENT_TIMESTAMP, c.content = '삭제된 댓글입니다.', c.imageUrl = null where c.parent.id = :postId")
-	void softDeleteByParentId(@Param("postId") Long postId);
-
-	@Modifying(clearAutomatically = true)
 	@Query(value = "update /*+ NO_PARALLEL(c) */ community_post_comment c set c.deleted = 1, c.deleted_at = SYSTIMESTAMP, c.content = '삭제된 댓글입니다.', c.image_url = null where c.user_id = :userId and c.deleted = 0", nativeQuery = true)
 	void softDeleteByUserId(@Param("userId") Long userId);
-
-	@Modifying(clearAutomatically = true)
+	
 	void deleteByParent_IdAndCommunityPostCommentIsNotNull(Long postId);
 
-	@Modifying(clearAutomatically = true)
 	void deleteByParent_IdAndCommunityPostCommentIsNull(Long postId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostImageRepository.java
@@ -16,17 +16,6 @@ public interface CommunityPostImageRepository extends JpaRepository<CommunityPos
 	@Query("SELECT cpi.imageUrl FROM CommunityPostImage cpi WHERE cpi.communityPost.id = :postId")
 	List<String> findImageUrlsByPostId(@Param("postId") Long postId);
 
-	@Query("""
-		  select i.imageUrl
-		  from CommunityPostImage i
-		  join i.communityPost p
-		  where p.user.id = :userId
-		""")
-	List<String> findImageKeysByOwner(Long userId);
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	List<CommunityPostImage> findAllByCommunityPostId(Long postId);
-
 	@Modifying(clearAutomatically = true)
 	void deleteByCommunityPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/CommunityPostRepository.java
@@ -1,5 +1,6 @@
 package kr.bi.greenmate.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -45,6 +46,9 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<CommunityPost> findWithLockById(Long postId);
+
+	@Query("SELECT p.id FROM CommunityPost p WHERE p.user.id = :userId")
+	List<Long> findIdsByUserId(@Param("userId") Long userId);
 
 	@EntityGraph(attributePaths = {"user"})
 	Slice<CommunityPost> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
@@ -25,5 +25,13 @@ public interface RecruitmentPostCommentRepository extends JpaRepository<Recruitm
 
 	List<RecruitmentPostComment> findByParentCommentIdIn(List<Long> parentIds);
 
-	void deleteByRecruitmentPostId(Long postId);
+	@Modifying(clearAutomatically = true)
+	void deleteByRecruitmentPost_IdAndParentCommentIsNotNull(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	void deleteByRecruitmentPost_IdAndParentCommentIsNull(Long postId);
+
+	@Modifying(clearAutomatically = true)
+	@Query(value = "update /*+ NO_PARALLEL(c) */ recruitment_post_comment c set c.content = '삭제된 댓글입니다.', c.image_url = null where c.user_id = :userId", nativeQuery = true)
+	void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import kr.bi.greenmate.entity.RecruitmentPostComment;
@@ -28,7 +29,8 @@ public interface RecruitmentPostCommentRepository extends JpaRepository<Recruitm
 	void deleteByRecruitmentPost_IdAndParentCommentIsNotNull(Long postId);
 
 	void deleteByRecruitmentPost_IdAndParentCommentIsNull(Long postId);
-	
+
+	@Modifying
 	@Query(value = "update /*+ NO_PARALLEL(c) */ recruitment_post_comment c set c.content = '삭제된 댓글입니다.', c.image_url = null where c.user_id = :userId", nativeQuery = true)
-	void softDeleteByUserId(Long userId);
+	void softDeleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostCommentRepository.java
@@ -25,13 +25,10 @@ public interface RecruitmentPostCommentRepository extends JpaRepository<Recruitm
 
 	List<RecruitmentPostComment> findByParentCommentIdIn(List<Long> parentIds);
 
-	@Modifying(clearAutomatically = true)
 	void deleteByRecruitmentPost_IdAndParentCommentIsNotNull(Long postId);
 
-	@Modifying(clearAutomatically = true)
 	void deleteByRecruitmentPost_IdAndParentCommentIsNull(Long postId);
-
-	@Modifying(clearAutomatically = true)
+	
 	@Query(value = "update /*+ NO_PARALLEL(c) */ recruitment_post_comment c set c.content = '삭제된 댓글입니다.', c.image_url = null where c.user_id = :userId", nativeQuery = true)
 	void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostImageRepository.java
@@ -3,6 +3,8 @@ package kr.bi.greenmate.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import kr.bi.greenmate.entity.RecruitmentPostImage;
@@ -11,4 +13,7 @@ import kr.bi.greenmate.entity.RecruitmentPostImage;
 public interface RecruitmentPostImageRepository extends JpaRepository<RecruitmentPostImage, Long> {
 
 	List<RecruitmentPostImage> findByRecruitmentPostId(Long postId);
+
+	@Query("select r.imageUrl from RecruitmentPostImage r where r.recruitmentPost.id = :postId")
+	List<String> findImageUrlsByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/repository/RecruitmentPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/RecruitmentPostRepository.java
@@ -1,5 +1,6 @@
 package kr.bi.greenmate.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +21,9 @@ public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost
 
 	@Query("SELECT r FROM RecruitmentPost r JOIN FETCH r.user WHERE r.id = :id")
 	Optional<RecruitmentPost> findByIdWithUser(@Param("id") Long id);
+
+	@Query("SELECT r.id FROM RecruitmentPost r WHERE r.user.id = :userId")
+	List<Long> findIdsByUserId(@Param("userId") Long userId);
     
 	@Query("SELECT ra.recruitmentPost FROM RecruitmentApplication ra JOIN FETCH ra.recruitmentPost.user WHERE ra.user.id = :userId ORDER BY ra.recruitmentPost.id DESC")
 	Slice<RecruitmentPost> findFirstParticipatedPostsByUserId(@Param("userId") Long userId, Pageable pageable);

--- a/src/main/java/kr/bi/greenmate/service/AuthService.java
+++ b/src/main/java/kr/bi/greenmate/service/AuthService.java
@@ -49,6 +49,7 @@ public class AuthService {
 	private final AgreementRepository agreementRepository;
 	private final UserAgreementRepository userAgreementRepository;
 	private final CommunityPostCleanupService communityPostCleanupService;
+	private final RecruitmentPostCleanupService recruitmentPostCleanupService;
 
 	@Transactional
 	public SignUpResponse signUp(SignUpRequest request, MultipartFile profileImage) {
@@ -185,5 +186,6 @@ public class AuthService {
 		if (affected == 0)
 			return;
 		communityPostCleanupService.deleteAllOfUser(user.getId());
+		recruitmentPostCleanupService.deleteAllOfUser(user.getId());
 	}
 }

--- a/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommentCreationService.java
@@ -54,7 +54,7 @@ public class CommentCreationService {
 			return null;
 
 		return communityPostCommentRepository
-			.findByIdAndParentId(parentCommentId, postId)
+			.findByIdAndParentIdAndDeletedFalse(parentCommentId, postId)
 			.orElseThrow(ParentCommentMismatchException::new);
 	}
 

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.bi.greenmate.repository.CommunityPostCommentRepository;
 import kr.bi.greenmate.repository.CommunityPostImageRepository;
-import kr.bi.greenmate.repository.CommunityPostRepository;
 import kr.bi.greenmate.repository.CommunityPostLikeRepository;
+import kr.bi.greenmate.repository.CommunityPostRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,7 +25,6 @@ public class CommunityPostCleanupService {
 	@Transactional
 	public void deleteAllOfUser(Long userId) {
 		List<String> imageKeys = new ArrayList<>();
-		// 1) 사용자가 작성한 커뮤니티 글을 계층적으로 하드 삭제
 		List<Long> postIds = communityPostRepository.findIdsByUserId(userId);
 		for (Long postId : postIds) {
 			List<String> postImageKeys = communityPostImageRepository.findImageUrlsByPostId(postId);
@@ -40,7 +39,6 @@ public class CommunityPostCleanupService {
 			communityPostRepository.deleteById(postId);
 		}
 
-		// 2) 타인의 글에 남긴 사용자의 댓글은 soft delete
 		imageKeys.addAll(communityPostCommentRepository.findImageUrlsByUserId(userId));
 		communityPostCommentRepository.softDeleteByUserId(userId);
 

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostCleanupService.java
@@ -1,5 +1,6 @@
 package kr.bi.greenmate.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.bi.greenmate.repository.CommunityPostCommentRepository;
 import kr.bi.greenmate.repository.CommunityPostImageRepository;
 import kr.bi.greenmate.repository.CommunityPostRepository;
+import kr.bi.greenmate.repository.CommunityPostLikeRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -17,15 +19,30 @@ public class CommunityPostCleanupService {
 	private final CommunityPostRepository communityPostRepository;
 	private final CommunityPostCommentRepository communityPostCommentRepository;
 	private final CommunityPostImageRepository communityPostImageRepository;
+	private final CommunityPostLikeRepository communityPostLikeRepository;
 	private final ApplicationEventPublisher publisher;
 
 	@Transactional
 	public void deleteAllOfUser(Long userId) {
-		List<String> imageKeys = communityPostImageRepository.findImageKeysByOwner(userId);
+		List<String> imageKeys = new ArrayList<>();
+		// 1) 사용자가 작성한 커뮤니티 글을 계층적으로 하드 삭제
+		List<Long> postIds = communityPostRepository.findIdsByUserId(userId);
+		for (Long postId : postIds) {
+			List<String> postImageKeys = communityPostImageRepository.findImageUrlsByPostId(postId);
+			List<String> commentImageKeys = communityPostCommentRepository.findImageUrlsByPostId(postId);
+			imageKeys.addAll(postImageKeys);
+			imageKeys.addAll(commentImageKeys);
 
-		communityPostCommentRepository.deleteByUser_Id(userId);
+			communityPostCommentRepository.deleteByParent_IdAndCommunityPostCommentIsNotNull(postId);
+			communityPostCommentRepository.deleteByParent_IdAndCommunityPostCommentIsNull(postId);
+			communityPostLikeRepository.deleteByCommunityPostId(postId);
+			communityPostImageRepository.deleteByCommunityPostId(postId);
+			communityPostRepository.deleteById(postId);
+		}
 
-		communityPostRepository.deleteByUser_Id(userId);
+		// 2) 타인의 글에 남긴 사용자의 댓글은 soft delete
+		imageKeys.addAll(communityPostCommentRepository.findImageUrlsByUserId(userId));
+		communityPostCommentRepository.softDeleteByUserId(userId);
 
 		if (!imageKeys.isEmpty()) {
 			publisher.publishEvent(new ImagesToDeleteEvent(imageKeys));

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -335,8 +334,7 @@ public class CommunityPostService {
 		retryFor = {
 			PessimisticLockException.class,
 			LockTimeoutException.class,
-			PessimisticLockingFailureException.class,
-			DeadlockLoserDataAccessException.class
+			PessimisticLockingFailureException.class
 		},
 		maxAttempts = 3,
 		backoff = @Backoff(delay = 50)

--- a/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/CommunityPostService.java
@@ -18,7 +18,6 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -357,7 +356,6 @@ public class CommunityPostService {
 			commentImageKeys.stream()
 		).collect(Collectors.toList());
 
-		// 댓글 계층적 하드 삭제: 대댓글(자식) → 최상위(부모)
 		communityPostCommentRepository.deleteByParent_IdAndCommunityPostCommentIsNotNull(postId);
 		communityPostCommentRepository.deleteByParent_IdAndCommunityPostCommentIsNull(postId);
 		communityPostLikeRepository.deleteByCommunityPostId(postId);
@@ -389,7 +387,6 @@ public class CommunityPostService {
 			throw new AccessDeniedException();
 		}
 
-		// 멱등성 가드: 이미 삭제된 경우 no-op
 		if (comment.isDeleted()) {
 			return;
 		}

--- a/src/main/java/kr/bi/greenmate/service/RecruitmentPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/RecruitmentPostCleanupService.java
@@ -1,0 +1,54 @@
+package kr.bi.greenmate.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.bi.greenmate.repository.RecruitmentPostCommentRepository;
+import kr.bi.greenmate.repository.RecruitmentPostImageRepository;
+import kr.bi.greenmate.repository.RecruitmentPostLikeRepository;
+import kr.bi.greenmate.repository.RecruitmentPostRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentPostCleanupService {
+
+	private final RecruitmentPostRepository recruitmentPostRepository;
+	private final RecruitmentPostCommentRepository recruitmentPostCommentRepository;
+	private final RecruitmentPostImageRepository recruitmentPostImageRepository;
+	private final RecruitmentPostLikeRepository recruitmentPostLikeRepository;
+	private final ApplicationEventPublisher publisher;
+
+	@Transactional
+	public void deleteAllOfUser(Long userId) {
+		List<String> imageKeys = new ArrayList<>();
+
+		// 1) 사용자가 작성한 모집글을 계층적으로 하드 삭제
+		List<Long> postIds = recruitmentPostRepository.findIdsByUserId(userId);
+		for (Long postId : postIds) {
+			List<String> postImageKeys = recruitmentPostImageRepository.findImageUrlsByPostId(postId);
+			imageKeys.addAll(postImageKeys);
+
+			recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNotNull(postId);
+			recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNull(postId);
+			recruitmentPostLikeRepository.deleteByRecruitmentPostId(postId);
+			// 이미지 엔티티 삭제 + 게시글 삭제
+			recruitmentPostImageRepository.findByRecruitmentPostId(postId).forEach(img -> {});
+			recruitmentPostImageRepository.deleteAll(recruitmentPostImageRepository.findByRecruitmentPostId(postId));
+			recruitmentPostRepository.deleteById(postId);
+		}
+
+		// 2) 타인의 모집글에 남긴 사용자의 댓글 soft delete
+		recruitmentPostCommentRepository.softDeleteByUserId(userId);
+
+		if (!imageKeys.isEmpty()) {
+			publisher.publishEvent(new ImagesToDeleteEvent(imageKeys));
+		}
+	}
+}
+
+

--- a/src/main/java/kr/bi/greenmate/service/RecruitmentPostCleanupService.java
+++ b/src/main/java/kr/bi/greenmate/service/RecruitmentPostCleanupService.java
@@ -27,7 +27,6 @@ public class RecruitmentPostCleanupService {
 	public void deleteAllOfUser(Long userId) {
 		List<String> imageKeys = new ArrayList<>();
 
-		// 1) 사용자가 작성한 모집글을 계층적으로 하드 삭제
 		List<Long> postIds = recruitmentPostRepository.findIdsByUserId(userId);
 		for (Long postId : postIds) {
 			List<String> postImageKeys = recruitmentPostImageRepository.findImageUrlsByPostId(postId);
@@ -36,13 +35,13 @@ public class RecruitmentPostCleanupService {
 			recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNotNull(postId);
 			recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNull(postId);
 			recruitmentPostLikeRepository.deleteByRecruitmentPostId(postId);
-			// 이미지 엔티티 삭제 + 게시글 삭제
-			recruitmentPostImageRepository.findByRecruitmentPostId(postId).forEach(img -> {});
+
+			recruitmentPostImageRepository.findByRecruitmentPostId(postId).forEach(img -> {
+			});
 			recruitmentPostImageRepository.deleteAll(recruitmentPostImageRepository.findByRecruitmentPostId(postId));
 			recruitmentPostRepository.deleteById(postId);
 		}
 
-		// 2) 타인의 모집글에 남긴 사용자의 댓글 soft delete
 		recruitmentPostCommentRepository.softDeleteByUserId(userId);
 
 		if (!imageKeys.isEmpty()) {

--- a/src/main/java/kr/bi/greenmate/service/RecruitmentPostService.java
+++ b/src/main/java/kr/bi/greenmate/service/RecruitmentPostService.java
@@ -110,7 +110,9 @@ public class RecruitmentPostService {
 		}
 
 		recruitmentPostLikeRepository.deleteByRecruitmentPostId(postId);
-		recruitmentPostCommentRepository.deleteByRecruitmentPostId(postId);
+		// 계층적 삭제: 자식 댓글 먼저, 그 다음 부모 댓글
+		recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNotNull(postId);
+		recruitmentPostCommentRepository.deleteByRecruitmentPost_IdAndParentCommentIsNull(postId);
 		recruitmentPostRepository.delete(post);
 
 		List<RecruitmentPostImage> images = recruitmentPostImageRepository.findByRecruitmentPostId(postId);


### PR DESCRIPTION
### 개요
커뮤니티 글 / 댓글 삭제, 회월 탈퇴 시의 로직을 수정했습니다.

### 변경사항
#### 커뮤니티 글 삭제: Hard delete
- 글을 비관적 락으로 조회 후 소유자를 검증합니다.
- 좋아요, 댓글, 이미지 엔티티를 계층적으로 삭제합니다.

#### 커뮤니티 댓글 삭제: Soft delete
- 댓글 삭제 시 content를 변경하고 imageURL을 제거, 삭제합니다.

#### 회원 탈퇴: Hard delete + Soft delete
- 본인이 쓴 커뮤니티 글은 Hard delete로 좋아요, 댓글, 이미지를 삭제합니다.
- 타인 글에 단 본인 댓글은 Soft delete로 내용, 작성자 닉네임을 변경합니다.


### 리뷰어에게 하고 싶은 말
회원 탈퇴 후 회원 엔티티의 값을 변경하지 않기 때문에 같은 닉네임, 이메일로 재가입 할 수 없는 문제가 있습니다. 이슈 규모가 너무 커지는 것 같아 새로운 PR을 만들어 올리도록 하겠습니다!