### PR TITLE
TEAM1-100 fix: 회원 탈퇴 후 같은 정보로 재가입할 수 있도록 변경

### DIFF
--- a/src/main/java/kr/bi/greenmate/repository/UserRepository.java
+++ b/src/main/java/kr/bi/greenmate/repository/UserRepository.java
@@ -9,18 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import kr.bi.greenmate.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByEmail(String email);
 
-	Optional<User> findByNickname(String nickname);
+	Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
-	boolean existsByNickname(String nickname);
-
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("""
-		  update User u
-		  set u.deletedAt = CURRENT_TIMESTAMP
-		  where u.id = :userId
-		    and u.deletedAt is null
-		""")
-	int markDeletedIfNotYet(Long userId);
+	boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 }


### PR DESCRIPTION
### 개요
기존 softDelete() 메서드 미사용으로 회원 탈퇴 후 같은 정보로 재가입 할 수 없는 문제가 있었습니다.

코드 수정으로 사용자가 탈퇴 후 재가입 할 수 있도록 변경하였습니다.

### 변경사항
- 회원 탈퇴 시 `softDelete()` 메서드로 `email`, `nickname`을 변경하여 재가입 시 UNIQUE 제약조건 위반이 발생하지 않도록 했습니다.
- 쿼리 메서드를 교체하여 탈퇴 사용자는 조회 / 중복에서 제외할 수 있도록 했습니다.

### 리뷰어에게 하고 싶은 말
지라에 있는 마지막 BE 이슈가 100번째 브랜치네요.

멘토님과 팀원 분들 덕에 너무 보람찬 방학이었던 것 같습니다.

정말 감사합니다!!!